### PR TITLE
Translate the tutorial into Japanese

### DIFF
--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -417,37 +417,30 @@ type CollectionRule {
 
 ### Naming and Scalars
 
-The last field in our simple `Collection` type is `bodyHtml`. To a user who is
-unfamiliar with the way that collections were implemented, it's not entirely
-obvious what this field is for; it's the body description of the specific
-collection. The first thing we can do to make this API better is just to rename
-it to `description`, which is a much clearer name.
+`Collection`型の最後のフィールドは`bodyHtml`です。  
+これはコレクションに対する説明文です。
+コレクションの詳細実装に詳しくない人間にとって、このフィールドがどういった目的で存在しているのか明らかではありません。
+ 
+このAPIの改善としてまずはじめにできることは、フィールド名を`description`に変えて意味を明確にすることです。
 
-*Rule #9: Choose field names based on what makes sense, not based on the
-implementation or what the field is called in legacy APIs.*
+*ルール #9: 歴史的経緯や詳細実装ではなく、意味のある概念に基づいてフィールド名を選ぶこと。*
 
-Next, we can make it non-nullable. As we talked about with the title field, it
-doesn't make sense to distinguish between the field being null and simply being
-an empty string, so we don't expose that in the API. Even if your database
-schema does allow records to have a null value for this column, we can hide that
-at the implementation layer.
+つぎにNullableを止めることができます。
+タイトルフィールドでも議論したとおり、Nullと空文字を区別する意味がないため、APIにおいてNullを許容しません。  
+たとえデータベーススキーマが当該のカラムにNullを許容していたとしても、それは詳細実装のレイヤに留めておくことができます。
 
-Finally, we need to consider if `String` is actually the right type for this
-field. GraphQL provides a decent set of built-in scalar types (`String`, `Int`,
-`Boolean`, etc) but it also lets you define your own, and this is a prime use
-case for that feature. Most schemas define their own set of additional scalars
-depending on their use cases. These provide additional context and semantic
-value for clients. In this case, it probably makes sense to define a custom
-`HTML` scalar for use here (and potentially elsewhere) when the string in
-question must be valid HTML.
+最後に、`String`が実際に正しい型なのかどうか考える必要があります。  
+GraphQLは標準で十分なスカラー型（`String`, `Int`, `Boolean`など）を提供していますが、一方でユーザ自身でカスタムスカラー型を定義することも可能にしています。
+本ケースはまさにその主要な利用場面です。
 
-Whenever you're adding a scalar field, it's worth checking your existing list of
-custom scalars to see if one of them would be a better fit. If you're adding a
-field and you think a new custom scalar would be appropriate, it's worth talking
-it over with your team to make sure you're capturing the right concept.
+多くのGraphQLスキーマでは。ユースケースに応じて独自のカスタムスカラー型を定義しています。  
+カスタムスカラー型はコンテキストや意味づけを与え、それらをクライアントに伝えます。
+今回の場合では、文字列が有効なHTMLであることを示すために、カスタムスカラー型`HTML`を定義すると良いでしょう。
 
-*Rule #10: Use custom scalar types when you're exposing something with specific
-semantic value.*
+カスタムスカラー型を追加するときはいつでも、既存のカスタムスカラー型を用いてより適切に目的を達成できるかどうかを確認しましょう。  
+カスタムスカラー型を追加しょうとしているとき、またその型が適切だと考えているときでも、チーム内でそれが正しい概念を表現しているかどうか話し合うことをおすすめします。
+
+*ルール #10: 特定の意味を持った値を表現する場合にはカスタムスカラー型を使うこと。*
 
 ### Pagination Again
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -223,7 +223,7 @@ GraphQLにおいて要素を追加するという操作は簡単ですが、そ�
 
 ### Starting point
 
-Restoring our naive fields adjusted for our new structure, we get:
+素朴な設計で存在していたフィールドを、我々の新しい構造に戻すと次のスキーマを得ます。
 
 ```graphql
 type Collection {
@@ -243,35 +243,34 @@ type CollectionRule {
 }
 ```
 
-Now we have a whole new host of design problems to resolve. We'll work through
-the fields in order top to bottom, fixing things as we go.
+これが我々が解決すべき新しい問題です。
+上から順にフィールドをみていき、ひとつずつ解決していきましょう。
 
 ### IDs and the `Node` Interface
 
-The very first field in our Collection type is an ID field, which is fine and
-normal; this ID is what we'll need to use to identify our collections throughout
-the API, in particular when performing actions like modifying or deleting them.
-However there is one piece missing from this part of our design: the `Node`
-interface. This is a very commonly-used interface that already exists in most
-schemas and looks like this:
+まずはじめに、コレクション型のIDフィールドに注目します。  
+良さそうに見えます。IDはAPIを通してとくに変更や削除操作を行う際に、コレクションを特定するために使われます。
+
+しかし、我々の設計にはひとつ欠けているものがあります。それは`Node`インターフェースです。  
+`Node`は既に多くのスキーマでひろく利用されているインターフェースで、以下ように与えられます。
+
 ```graphql
 interface Node {
   id: ID!
 }
 ```
-It hints to the client that this object is persisted and retrievable by the
-given ID, which allows the client to accurately and efficiently manage local
-caches and other tricks. Most of your major identifiable business objects
-(e.g. products, collections, etc) should implement `Node`.
 
-The beginning of our design now just looks like:
+これはクライアントに対して、本オブジェクトは永続化されていてIDを用いて取得できることを知らせるヒントであり、クライアントは正確かつ効率的にローカルキャッシュを管理することができます。  
+特定可能な主要なビジネスオブジェクト（例えば商品やコレクションなど）は`Node`インターフェースを実装するべきです。
+
+APIデザインは次のようになります。
 ```graphql
 type Collection implements Node {
   id: ID!
 }
 ```
 
-*Rule #5: Major business-object types should always implement `Node`.*
+*ルール #5: 主要なビジネスオブジェクト型は`Node`インターフェースを実装する。*
 
 ### Rules and Subobjects
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -1,25 +1,25 @@
 # Tutorial: Designing a GraphQL API
 
-本チュートリアルは[Shopify](https://www.shopify.ca/)によって社内向けに作られました。  
+本チュートリアルは[Shopify](https://www.shopify.ca/)によって社内向けに作られました。
 我々は本チュートリアルがGraphQL APIを利用する全ての方にとって役に立つと考え、公開版を作成するに至りました。
 
-本チュートリアルは、Shopifyのプロダクション環境における過去３年間のスキーマ構築と発展から得た学びに基づいています。  
-本チュートリアルはこれまでも発展してきましたし、今後も更新され続けるでしょう。  
+本チュートリアルは、Shopifyのプロダクション環境における過去３年間のスキーマ構築と発展から得た学びに基づいています。
+本チュートリアルはこれまでも発展してきましたし、今後も更新され続けるでしょう。
 ですから、本チュートリアルに盲目的に従ってすべてを取り込もうとせず、あなたの目的や状況に応じて役に立つ部分を適用してください。
 
 ## Intro
 
-ようこそ！本ドキュメントでは、新しいGraphQL APIの（あるいは既存のGraphQL APIの拡張の）設計方法をみていきます。  
+ようこそ！本ドキュメントでは、新しいGraphQL APIの（あるいは既存のGraphQL APIの拡張の）設計方法をみていきます。
 APIの設計は、繰り返し、実験し、ビジネスドメインの十分な理解を得るに値する挑戦的な仕事です。
 
 ## Step Zero: Background
 
-本チュートリアルでは、あるE-コマース運営企業の開発業務を想定します。  
-あなたはすでに商品情報を公開するための非常に小規模なGraphQL APIをもっています。  
-あなたのチームは、ちょうどコレクション機能のバックエンド部分の実装を終え、本機能をAPIで公開したいと考えています。  
+本チュートリアルでは、あるE-コマース運営企業の開発業務を想定します。
+あなたはすでに商品情報を公開するための非常に小規模なGraphQL APIをもっています。
+あなたのチームは、ちょうどコレクション機能のバックエンド部分の実装を終え、本機能をAPIで公開したいと考えています。
 
-コレクションは新しい主要機能で商品をグループにまとめることができます。  
-例えばあなたの所有するすべてのTシャツ商品をまとめたコレクションが考えられます。  
+コレクションは新しい主要機能で商品をグループにまとめることができます。
+例えばあなたの所有するすべてのTシャツ商品をまとめたコレクションが考えられます。
 コレクションはWebサイトにおいて商品をまとめて表示する際に利用できますし、自動化タスクにも利用できます（特定のコレクションの商品に対してのみ、ある割引価格と適用したい場合など。）
 
 バックエンドではコレクション機能は以下のように実装されました。
@@ -107,27 +107,27 @@ type CollectionMembership {
 }
 ```
 
-このシンプルな表現ではすべての値フィールド、フィールド名、Null制約の情報を取り除いてあります。  
-残ったものはGraphQLのように見える何かに過ぎませんが、型や関連性といった高いレベルで考えさせてくれます。  
+このシンプルな表現ではすべての値フィールド、フィールド名、Null制約の情報を取り除いてあります。
+残ったものはGraphQLのように見える何かに過ぎませんが、型や関連性といった高いレベルで考えさせてくれます。
 
-*ルール #1: 詳細に取り掛かる前に、高いレベルでオブジェクトとそれらの関連性を考えることからはじめよ。* 
+*ルール #1: 詳細に取り掛かる前に、高いレベルでオブジェクトとそれらの関連性を考えることからはじめよ。*
 
 ## Step Two: A Clean Slate
 
 それではこのシンプルな構造を用いて、当初の設計における主要な誤りをみていきましょう。
 
-以前に述べたとおり、我々の詳細実装は、手動コレクションと自動コレクション、そしてコレクションと商品を結合するコレクターテーブルを定義しています。  
+以前に述べたとおり、我々の詳細実装は、手動コレクションと自動コレクション、そしてコレクションと商品を結合するコレクターテーブルを定義しています。
 素朴なAPIデザインは明らかに詳細実装に依存して構築されていますが、これは誤りです。
 
-このアプローチの根本的な問題は、APIは詳細実装とは異なる目的の振る舞いを持ち、また多くの場合は抽象度のレベルも異なることです。  
+このアプローチの根本的な問題は、APIは詳細実装とは異なる目的の振る舞いを持ち、また多くの場合は抽象度のレベルも異なることです。
 今回のケースでは、我々の詳細実装によって多くの迷いが生じました。
 
 ### Representing `CollectionMembership`s
 
-現状のスキーマに `CollectionMembership` が含まれていることに気がついたかもしれません。  
-コレクションメンバーシップテーブルは商品とコレクションの間の他対他の関連を表現するために使われます。  
+現状のスキーマに `CollectionMembership` が含まれていることに気がついたかもしれません。
+コレクションメンバーシップテーブルは商品とコレクションの間の他対他の関連を表現するために使われます。
 最後の部分をもう一度読んでください、「*商品とコレクションの間*」の関連とあります。
-ビジネスドメインのセマンティクスからすれば、コレクションメンバーシップは意味を持っていないのです。  
+ビジネスドメインのセマンティクスからすれば、コレクションメンバーシップは意味を持っていないのです。
 コレクションメンバーシップは詳細実装です。
 
 これはつまり、我々のAPIに含まれないということを意味します。
@@ -160,23 +160,19 @@ type AutomaticCollectionRule { }
 
 ### Representing Collections
 
-This API design still has one major flaw, though it's one that's probably much
-less obvious without a really thorough understanding of the business domain. In
-our existing design, we model AutomaticCollections and ManualCollections as two
-different types, each implementing a common Collection interface. Intuitively
-this makes a fair bit of sense: they have a lot of common fields, but are
-still distinctly different in their relationships (AutomaticCollections have
-rules) and some of their behaviour.
+ビジネスドメインの十分な理解がないと気づかないかもしれませんが、まだ今のAPI設計には大きな誤りがひとつ残されています。
 
-But from a business model perspective, these differences are also basically an
-implementation detail. The defining behaviour of a collection is that it groups
-products; the method of choosing those products is secondary. We could expand
-our implementation at some point to permit some third method of choosing
-products (machine learning?) or to permit mixing methods (some rules and some
-manually added products) and *they would still just be collections*. You could
-even argue that the fact we don't permit mixing right now is an implementation
-failure. All of this to say is that the shape of our API should really look more
-like this:
+現状の設計では、手動コレクションと自動コレクションは共通のコレクションインターフェースを実装した異なる２つの型として定義されています。
+直感的には理にかなっているようにみえます。
+それらは多数の共通するフィールドを持っていますが、関連性（自動コレクションは選択ルールをもちます）と振る舞いにおいて明確な違いがあります。
+
+ビジネスモデルの観点からすれば、これらの差異も基本的には詳細実装です。
+コレクションの振る舞いとは、商品をグループにまとめることであり、どのようにしてそれら商品を選ぶかは従属的なものだからです。
+我々はいずれは第３の商品選択方法（機械学習？）を許容するかもしれませんし、複数の選択方法を組み合わせるかもしれません（選択ルールもあれば手動で選択するものもある。）
+それでも、*それらはコレクションにすぎないでしょう。*
+
+現時点において選択方法の組み合わせを見込んで許容しないのは、詳細実装の落ち度だと主張することもできます。
+つまり、APIデザインは次のようにすべきだと主張することもできるということです。
 
 ```graphql
 type Collection {
@@ -188,37 +184,29 @@ type Collection {
 type CollectionRule { }
 ```
 
-That's really nice. The immediate concern you may have at this point is that
-we're now pretending ManualCollections have rules, but remember that this
-relationship is a list. In our new API design, a "ManualCollection" is just a
-Collection whose list of rules is empty.
+それは良さそうにみえます。
+手動コレクションがルールを持っているように振る舞うことを懸念されるかもしれません。
+しかし、思い出してください、これは関連のリストなのです。
+我々のあたらしいAPI設計では、手動コレクションは単に選択ルールが無い（空）コレクションにすぎません。
 
 ### Conclusion
 
-Choosing the best API design at this level of abstraction necessarily requires
-you to have a very deep understanding of the problem domain you're modeling.
-It's hard in a tutorial setting to provide that depth of context for a specific
-topic, but hopefully the collection design is simple enough that the reasoning
-still makes sense. Even if you don't have this depth of understanding
-specifically for collections, you still absolutely need it for whatever domain
-you're actually modeling. It is critically important when designing your API
-that you ask yourself these tough questions, and don't just blindly follow the
-implementation.
+この抽象レベルにおけて最適なAPI設計を行うには、モデリング対象としているビジネスドメインへの深い理解が要求されます。
+ュートリアルの設定だけで特定の話題に関するコンテキストの深さをお伝えするのは困難ですが、本節のコレクション設計の例を通して、APIの設計方針を説明できていれば幸いです。
 
-On a closely related note, a good API does not model the user interface either.
-The implementation and the UI can both be used for inspiration and input into
-your API design, but the final driver of your decisions must always be the
-business domain.
+実際にモデリングしている対象が何であれコレクション設計の理解は必ず必要となります。
+API設計を行っている際には、どうあるべきかを自分自身に問い続ること、詳細実装に盲目的に従わないことが非常に重要です。
 
-Even more importantly, existing REST API choices should not necessarily be
-copied. The design principles behind REST and GraphQL can lead to very different
-choices, so don't assume that what worked for your REST API is a good choice for
-GraphQL.
+関連する点として、良いAPI設計はユーザインターフェースにも従属しません。
+詳細実装とUIのいずれも着想を得るためのインプットとして用いることができるものの、設計方針は常にビジネスドメインに従わなければなりません。
 
-As much as possible let go of your baggage and start from scratch.
+さらに重要な点として、既存のREST APIにおける決定事項を不必要に踏襲しないことです。
+REST APIとGraphQLの背後にある設計思想はまったく異なった決定を導く可能性があります。
+ですから、REST APIでうまくいったことがGraphQLでもそうであると想定してはいけません。
 
-*Rule #3: Design your API around the business domain, not the implementation,
-user-interface, or legacy APIs.*
+可能なかぎり、これまでの常識を取り外し、ゼロから考えるようにしましょう。
+
+*ルール #3: 詳細実装でも、ユーザインタフェースでも、あるいはレガシーなAPIでもなく、ビジネスドメインに従ってAPI設計を行うこと。*
 
 ## Step Three: Adding Detail
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -364,33 +364,28 @@ type PageInfo {
 
 ###  Strings
 
-Next up is the `title` field. This one is legitimately fine the way it is. It's
-a simple string, and it's marked non-null because all collections must have a
-title.
+次に登場するのは`title`フィールドです。これは本当に現状のままで問題ないでしょう。  
+すべてのコレクションはタイトルを持っているはずなので、非Nullのシンプルな文字列型です。
 
-*Protip: As with booleans and lists, it's worth noting that GraphQL does
-distinguish between empty strings (`""`) and nulls (`null`), so if you need a
-nullable string make sure there is a legitimate semantic difference between
-not-present (`null`) and present-but-empty (`""`). You can often think of empty
-strings as meaning "applicable, but not populated", and null strings meaning
-"not applicable".*
+*Protip: Booleanやリストと同様に、GraphQLが空文字列(`""`)とNull(`null`)を区別することに注意しましょう。
+NullableなStringを使う場合は、存在しないこと(`null`)と、存在しているが空文字列(`""`)の状態について意味的に本当に差異があるか確認ましょう。*
+空文字列を”許容可能だが値が埋められていない”ものとし、Nullを”許容不可能”なものと考えることができます*
 
 ### IDs and Relations
 
-Now we come to the `imageId` field. This field is a classic example of what
-happens when you try and apply REST designs to GraphQL. In REST APIs it's
-pretty common to include the IDs of other objects in your response as a way to
-link together those objects, but this is a major anti-pattern in GraphQL.
-Instead of providing an ID, and forcing the client to do another round-trip to
-get any information on the object, we should just include the object directly
-into the graph - that's what GraphQL is for after all. In REST APIs this pattern
-often isn't practical, since it inflates the size of the response significantly
-when the included objects are large. However, this works fine in GraphQL because
-every field must be explicitly queried or the server won't return it.
+さて、`imageId`フィールドに取り掛かりましょう。
+このフィールドは、RESTの思想をGraphQLに適用しようとしたときに何がおこるかを示す典型的な例です。
+REST APIでは、オブジェクト同士を結びつける手段のひとつとして、レスポンスの中に他のオブジェクトのIDを含める方法が一般的です。
+しかし、これはGraphQLにおける代表的なアンチパターンです。
 
-As a general rule, the only ID fields in your design should be the IDs of the
-object itself. Any time you have some other ID field, it should probably be an
-object reference instead. Applying this to our schema so far, we get:
+IDを与えて、対象となるオブジェクトを取得するための別のリクエストを強いる代わりに、オブジェクトをグラフに直接含めるべきです。
+詰まるところ、これこそがGraphQLが求めるものです。  
+含まれるオブジェクトが大きい場合にレスポンスのサイズも膨れ上がるため、REST APIにおいてこの設計はしばし実用的ではありません。  
+しかしGraphQLでは、フィールドを明示的にクエリで要求しない限りはサーバーは何も行わないため、この設計がうまくいくのです。
+
+一般的な指針として、IDフィールドはオブジェクト自身の識別子を表す場合のみ使うべきです。  
+他のオブジェクトIDをフィールドとしてもつ場合、そのオブジェクトへ参照であるべきかもしれません。  
+この指針をこれまでの我々のスキーマに適用すると、次のようになります。
 
 ```graphql
 type Collection implements Node {
@@ -418,7 +413,7 @@ type CollectionRule {
 }
 ```
 
-*Rule #8: Always use object references instead of ID fields.*
+*ルール #8: IDフィールドの代わりとして常にオブジェクトの参照を使うこと。*
 
 ### Naming and Scalars
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -640,29 +640,26 @@ mutationにおいても類似する問題に対処しなければなりません
 
 ### Input: Structure, Part 1
 
-Now that we know which mutations we want to write, we get to figure out what
-their input structures look like. If you've been browsing any of the real
-production schemas that are publicly available, you may have noticed that many
-mutations define a single global `Input` type to hold all of their arguments:
-this pattern was a requirement of some legacy clients but is no longer needed
-for new code; we can ignore it.
+さて、これで我々がどのようなmutationが必要なのかが分かりました。
+つぎは入力の型を明らかにしていきます。
+一般に公開され利用可能な本物のスキーマを見たことがあれば、多くのmutationが、全ての引数を内包したグローバルな`Input`型をもっていることに気がついたかもしれません。
+このパターンはいつかのレガシーなクライアントで必要とされた要件でしたが、いまでは不要になったため考慮しないで構いません。
 
-For many simple mutations, an ID or a handful of IDs are all that is needed,
-making this step quite simple. Among collections, we can quickly knock out the
-following mutation arguments:
-- `delete`, `publish` and `unpublish` all simply need a single collection ID
-- `addProducts` and `removeProducts` both need the collection ID as well as a
-  list of product IDs
+シンプルなmutationに対しては、ひとつのIDか片手で数えられる程度のIDがあれば十分です。
+簡単に済ませてしまいましょう。
+コレクションに関して言えば、以下のmutation引数に関してはすぐに答えが出せます。
 
-This leaves us with only three remaining "complicated" inputs to design:
+- `delete`と`publish`、`unpublish`はすべて単純にひとつのコレクションのIDが必要
+- `addProducts`と`removeProducts`はどちらもコレクションのIDに加えて商品のIDリストが必要
+
+残った他の３つの"複雑な"入力に対処していきます。
 - create
 - update
 - reorderProducts
 
-Let's start with create. A very naive input might look kind of like our original
-naive collection model when we started, but we can already do better than that.
-Based on our final collection model and the discussion of relationships above,
-we can start with something like this:
+createからです。
+極めて素朴な入力の型は、我々が当初考えていた素朴なコレクションモデルのようなものになるかもしれません。しかし我々はすでにより良い方法を知っています。
+最終的なコレクションの型と、関連に関する先の議論をもとにして考えると、以下のような案から考えていくことができます。
 
 ```graphql
 type Mutation {
@@ -686,15 +683,13 @@ input CollectionRuleInput {
 }
 ```
 
-First a quick note on naming: you'll notice that we named all of our mutations
-in the form `collection<Action>` rather than the more naturally-English
-`<action>Collection`. Unfortunately, GraphQL does not provide a method for
-grouping or otherwise organizing mutations, so we are forced into
-alphabetization as a workaround. Putting the core type first ensures that all of
-the related mutations group together in the final list.
+まずは命名について簡単にみていきます。
+すべてのmutationに対して、自然な英語では`<action>Collection`であるはずが、あえて`collection<Action>`の形式の名前をつけています。
+残念ながら、GraphQLはmutationをまとめたり整理するための手立てを提供しません。
+そこで、ワークアラウンドとして無理やりアルファベット順に並べているのです。
+対象となる型名を接頭辞とすることで、関係するmutationをまとめて並べることができます。
 
-*Rule #17: Prefix mutation names with the object they are mutating for
- alphabetical grouping (e.g. use `orderCancel` instead of `cancelOrder`).*
+*ルール #17: アルファベット順でグループ化するために、mutationの接頭辞に操作対象のオブジェクト名を用いること（例えば`cancelOrder`ではなく`orderCancel`とする。）*
 
 ### Input: Scalars
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -587,52 +587,36 @@ CRUDに従おうとすると、すぐに`update`が巨大になるというこ�
 
 ### Manipulating Relationships
 
-The `update` mutation still has far too many responsibilities so it makes sense
-to continue splitting it up, but we will deal with these actions separately
-since they're worth thinking about from another dimension as well: the
-manipulation of object relationships (e.g. one-to-many, many-to-many). We've
-already considered the use of IDs vs embedding, and the use of pagination vs
-arrays in the read API, and there are some similar issues to deal with when
-mutating these relationships.
+`update` mutationは依然として大きすぎる責務を負っているため、引き続き分解を進めましょう。
+とはいえ、分解した操作もそれぞれ別の次元（例えば１対多や多対多の関係性に関する操作）から考えてみる価値があるので、後ほど順に見ていきます。
+我々はすでにIDとオブジェクトの埋め込みの使い方、あるいはページネーションとリストの使い分けについてみてきました。
+mutationにおいても類似する問題に対処しなければなりません。
 
-For the relationship between products and collections, there are a couple of
-styles we could broadly consider:
-- Embedding the entire relationship (e.g. `products: [ProductInput!]!`) into the
-  update mutation is the CRUD-style default, but of course it quickly becomes
-  inefficient when the list is large.
-- Embedding "delta" fields (e.g. `productsToAdd: [ID!]!` and
-  `productsToRemove: [ID!]!`) into the update mutation is more efficient since
-  only the changed IDs need to be specified instead of the entire list, but it
-  still keeps the actions tied together.
-- Splitting it up entirely into separate mutations (`addProduct`,
-  `removeProduct`, etc.) is the most powerful and flexible but also the most
-  work.
+商品とコレクションの関連については、いくつかの検討可能な設計パターンがあります。
+- update mutationに関連全体（例えば`products: [ProductInput!]!`）を埋め込むCRUDスタイルの方法。
+しかし、当然ながら関連のリストが大きくなるにつれて間もなく非効率になる。
+- “差分”フィールド（例えば`productsToAdd: [ID!]!`と`andproductsToRemove: [ID!]!`）をupdate mutationに埋め込む方法。
+変更のあるIDだけを必要とするため関連全体の場合よりも効率的。しかし依然として複数の操作をひとつにまとめてしまっている。
+- 別々のmutation（`addProduct`や`removeProduct`など）に分ける方法。柔軟、効率的で、最もうまくいく。
 
-The last option is generally the safest call, especially since mutations like
-this will usually be distinct logical actions anyway. However, there are a lot
-of factors to consider:
-- Is the relationship large or paginated? If so, embedding the entire list is
-  definitely impractical, however either delta fields or separate mutations
-  could still work. If the relationship is always small though (especially if
-  it's one-to-one), embedding may be the simplest choice.
-- Is the relationship ordered? The product-collection relationship is ordered,
-  and permits manual reordering. Order is naturally supported by the embedded
-  list or by separate mutations (you can add a `reorderProducts` mutation)
-  but isn't an option for delta fields.
-- Is the relationship mandatory? Products and collections can both exist on
-  their own outside of the relationship, with their own create/delete lifecycle.
-  If the relationship were mandatory (i.e. products must be in a collection)
-  then this would strongly suggest separate mutations because the action would
-  actually be to *create* a product, not just to update the relationship.
-- Do both sides have IDs? The collection-rule relationship is mandatory (rules
-  can't exist without collections) but rules don't even have IDs; they are
-  clearly subservient to their collection, and since the relationship is also
-  small, embedding the list is actually not a bad choice here. Anything else
-  would require rules to be individually identifiable and that feels like
-  overkill.
+本ケースのようなmutationは実際には異なる個別のロジックを持つため、最後の選択肢が一般に最も安全だとされます。
+しかし、考慮すべき要素がいくつもあります。
+- 関連のリストは巨大であったり、ページネーションされていますか？
+  もしそうなら、リスト全体を埋め込む方法は非現実的です。
+  しかし差分埋め込みやmutationの分割といった方法はうまくいくかもしれません。
+  もし関連のリストがいつも小さいと仮定できるなら（特に１対１の場合）、リスト埋め込みの方法が最もシンプルでしょう。
+- 関連のリストは順序づけされていますか？
+  商品ーコレクションの関連は順序づけされていて、手動で並び替えることが許されていました。
+  順序づけは、リスト埋め込みやmutation分割（例えば`reorderProducts`を追加できます）では自然な方法で実現できますが、差分埋め込みの場合には困難です。
+- 関連は必須ですか？商品とコレクションは関連とは別に存在することができ、それぞれが独自の作成/削除のライフサイクルをもっています。
+  もし関連が必須があれば（例えば商品はいずれかのコレクションに所属している必要がある、など）、mutation分割を強く推めます。
+  なぜなら、その操作は実際に商品を*作成する*はずで、関連の更新にとどまらないはずです。
+- 関連をもつ双方のオブジェクトがもちますか？
+  コレクションールールの関連は必須（ルールをはコレクションから離れて存在できません）ですが、ルールはIDすらもちません。
+  ルールは明らかにコレクションに従属していますし、関連の数も小さいので、ここではリスト埋め込みが悪くない選択です。
+  他のオブジェクトがルールを一意に識別する必要があるかもしれませんが、それはやりすぎのように感じられます。
 
-*Rule #15: Mutating relationships is really complicated and not easily
- summarized into a snappy rule.*
+*ルール #15: 関連に対する操作は複雑で、ひとつの便利な指針で語ることはできない。*
 
  If you stir all of this together, for collections we end up with the following
  list of mutations:

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -210,19 +210,16 @@ REST APIとGraphQLの背後にある設計思想はまったく異なった決�
 
 ## Step Three: Adding Detail
 
-Now that we have a clean structure to model our types, we can add back our
-fields and start to work at that level of detail again.
+我々の型をモデリングするクリーンな構造を手に入れることができました。  
+もう一度、細部に視点を移して省いていたフィールドを追加していきましょう。
 
-Before we start adding detail, ask yourself if it's really needed at this
-time. Just because a database column, model property, or REST attribute may
-exist, doesn't mean it automatically needs to be added to the GraphQL schema.
+詳細情報を追加する前に、現時点においてその情報が本当に必要かどうか自問自答してください。
+なぜなら、データベースのカラムやモデルのプロパティ、RESTの属性としてその詳細情報が存在していたとしても、それがそのままGraphQLでも必要になるとは限らないからです。
 
-Exposing a schema element (field, argument, type, etc) should be driven by an
-actual need and use case. GraphQL schemas can easily be evolved by adding
-elements, but changing or removing them are breaking changes and much more
-difficult.
+スキーマの要素（フィールドや引数、型など）を公開する場合、実際の必要性やユースケースによって検討されるべきです。  
+GraphQLにおいて要素を追加するという操作は簡単ですが、それを変更したり削除することは破壊的な変更であり、難しい操作です。
 
-*Rule #4: It's easier to add fields than to remove them.*
+*ルール #4: フィールドの追加操作は削除操作よりも簡単。*
 
 ### Starting point
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -693,20 +693,16 @@ input CollectionRuleInput {
 
 ### Input: Scalars
 
-This draft is a lot better than a completely naive approach, but it still isn't
-perfect. In particular, the `description` input field has a couple of issues. A
-non-null `HTML` field makes sense for the output of a collection's description,
-but it doesn't work as well for input for a couple of reasons. First-off, while
-`!` denotes non-nullability on output, it doesn't mean quite the same thing on
-input; instead it denotes more the concept of whether a field is "required". A
-required field is one the client must provide in order for the request to
-proceed, and this isn't true for `description`. We don't want to prevent clients
-from creating collections if they don't provide a description (or equivalently,
-we don't want to force them to provide a useless `""`), so we should make
-`description` non-required.
+GraphQLの草案は素朴なものよりもかなり良くなっていますが、まだ完全ではありません。
+とくに`description`入力フィールドはいくつか問題をかかえています。
+出力時にはコレクションの説明として非Nullの`HTML`フィールドが適していましたが、入力としてはいくつかの理由でうまくいきません。
+まずはしめに、`!`記号は出力において非Nullを示すために用いましたが、入力に対してまったく同じ意味をなすとは言えません。
+`!`記号はむしろフィールドが"必須"であるか否かを意味します。
+必須フィールドはリクエストを処理するためにクライアント側が必ず渡す必要のあるものですが、`description`はこの類ではありません。
+クライアントが説明文を渡さなかった場合でも、コレクションを作成する処理を妨げたくありません（同じく、クライアントに無用な空文字列`""`を渡すことを強要したくありません。）
+したがって`description`は非必須とするべきです。
 
-*Rule #18: Only make input fields required if they're actually semantically
- required for the mutation to proceed.*
+*ルール #18: mutation処理を遂行するうえで意味的に本当に必要である場合に限り、入力フィールドを必須とすること。*
 
 The other issue with `description` is its type; this may seem counter-intuitive
 since it is already strongly-typed (`HTML` instead of `String`) and we've been

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -618,8 +618,7 @@ mutationにおいても類似する問題に対処しなければなりません
 
 *ルール #15: 関連に対する操作は複雑で、ひとつの便利な指針で語ることはできない。*
 
- If you stir all of this together, for collections we end up with the following
- list of mutations:
+以上の議論を踏まえると、コレクションに対するmutationは以下のようになるでしょう。
 - create
 - delete
 - update
@@ -629,17 +628,15 @@ mutationにおいても類似する問題に対処しなければなりません
 - removeProducts
 - reorderProducts
 
-Products we split into their own mutations, because the relationship is large
-and ordered. Rules we left inline because the relationship is small, and rules
-are sufficiently minor to not have IDs.
+商品については関連の数が多く、順序づけもなされているため、独自のmutationを切り出しました。
+ルールはインライン（リスト埋め込み）のままとしました。
+なぜなら、関連の数が少なく、IDを持たせなくて済む程度にマイナーな概念だからです。
 
-Finally, you may note our product mutations act on sets of products, for example
-`addProducts` and not `addProduct`. This is simply a convenience for the client,
-since the common use case when manipulating this relationship will be to add,
-remove, or reorder more than one product at a time.
+最後に、商品に対する操作の名前が複数形（`addProduct`ではなく`addProducts`）になっていることに触れておきます。
+これは単純にクライアント側の利便性を考慮しています。
+一般的なユースケースを考えた場合、商品に対する操作は単一の商品ではなく、複数のものを対象として追加、削除、並べ替えを実行することになるからです。
 
-*Rule #16: When writing separate mutations for relationships, consider whether
- it would be useful for the mutations to operate on multiple elements at once.*
+*ルール #16: 関連に対するmutationを分けて実装するときには、一度に複数の要素に対して実行することが便利かどうか検討すること。*
 
 ### Input: Structure, Part 1
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -704,39 +704,35 @@ GraphQLの草案は素朴なものよりもかなり良くなっていますが�
 
 *ルール #18: mutation処理を遂行するうえで意味的に本当に必要である場合に限り、入力フィールドを必須とすること。*
 
-The other issue with `description` is its type; this may seem counter-intuitive
-since it is already strongly-typed (`HTML` instead of `String`) and we've been
-all about strong typing so far. But again, inputs behave a little differently.
-Validation of strong typing on input happens at the GraphQL layer before any
-"userspace" code gets run, which means that realistically clients have to deal
-with two layers of errors: GraphQL-layer validation errors, and business-layer
-validation errors (for example something like: you've reached the limit of
-collections you can create with your current storage). In order to simplify this
-process, we intentionally weakly type input fields when it might be difficult
-for the client to validate up-front. This lets the business-logic side handle
-all of the validation, and lets the client only deal with errors from one spot.
+`description`に関するもうひとつの問題はその型です。
+この問題は直感に反するかもしれません。
+`description`はすでに強い型付け（`String`ではなく`HTML`）がされており、またこれまで強い型付けを議論してきました。
+しかし、繰り返しになりますが、入力は出力と少し異なる振る舞いを行うのです。
 
-*Rule #19: Use weaker types for inputs (e.g. `String` instead of `Email`) when
- the format is unambiguous and client-side validation is complex. This lets the
- server run all non-trivial validations at once and return the errors in a
- single place in a single format, simplifying the client.*
+強い型付けに対する値の検証は、ユーザ空間のコードが実行されるよりも前でに、GraphQLのレイヤーで実行されます。
+つまり、クライアントはGraphQLレイヤーにおける検証とビジネスドメインレイヤーにおける検証の両方で発生するエラーをそれぞれ対応する必要があるということです。
+（例えば、現状の許容ストレージ内で生成できるコレクションの上限に達した場合など）
 
-It is important to note, though, that this is not an invitation to weakly-type
-all your inputs. We still use strongly-typed enums for the `field` and
-`relation` values on our rule input, and we would still use strong typing for
-certain other inputs like `DateTime`s if we had any in this example. The key
-differentiating factors are the complexity of client-side validation and the
-ambiguity of the format. HTML is a well-defined, unambiguous specification, but
-is quite complex to validate. On the other hand, there are hundreds of ways to
-represent a date or time as a string, all of them reasonably simple, so it
-benefits from a strong scalar type to specify which format we expect.
+処理を簡単にするために、クライアント側で事前に検証を行うことが難しい場合には、我々は入力対して意図的に弱い型付けを行います。
+これにより、ビジネスロジックレイヤーがすべての検証を行い、クライアントも一箇所から発生するエラーだけに対処するだけで済みます。
 
-*Rule #20: Use stronger types for inputs (e.g. `DateTime` instead of `String`)
- when the format may be ambiguous and client-side validation is simple. This
- provides clarity and encourages clients to use stricter input controls (e.g. a
- date-picker widget instead of a free-text field).*
+*ルール #19: フォーマットが曖昧であったり、クライアント側の検証が複雑な場合には、入力に対して弱い型付け（`Email`ではなく`String`）を行うこと。
+ これによりサーバーは一度にすべての検証を実行し、単一のフォーマットでエラーを報告することになり、結果としてクライアント非常にシンプルになる。*
+
+これはすべての入力に対して弱い型付けを推奨している訳ではないことに注意してください。
+我々はroleの入力における`field`と`relation`フィールドに強い型付けをもったenumを用いています。
+例えば`DateTime`のような特定の値入力に対しても、強い型付けを使うことがあるでしょう。
+
+違いを生む要因はクライアント側検証の複雑さとフィーマットの曖昧さです。
+HTMLはうまく定義されていて、明瞭な仕様がありますが、検証を行うには極めて複雑です。
+他方で日時や日付を表現する文字列には何百の表現方法があり、それらすべてが適切にシンプルなフォーマットをもっています。
+したがって、サーバーが期待するフォーマットを指定するために強い型付けを行うと便利です。
+
+*ルール #20: フォーマットが曖昧でクライアント側検証がシンプルな場合は強い型付け（`String`ではなく`DateTime`）を行うこと。
+ 型付けにより明確さを得られ、クライアントにより厳しい入力値管理（フリーテキスト入力ではなくカレンダーウィジェットを用いる）を促します。*
 
 ### Input: Structure, Part 2
+
 
 Continuing on to the update mutation, it might look something like this:
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -274,37 +274,29 @@ type Collection implements Node {
 
 ### Rules and Subobjects
 
-We will consider the next two fields in our Collection type together: `rules`,
-and `rulesApplyDisjunctively`. The first is pretty straightforward: a list of
-rules. Do note that both the list itself and the elements of the list are marked
-as non-null: this is fine, as GraphQL does distinguish between `null` and `[]`
-and `[null]`. For manual collections, this list can be empty, but it cannot be
-null nor can it contain a null.
+コレクション内の、つぎの２つのフィールド`rules`と`rulesApplyDisjunctively`をみていきましょう。  
 
-*Protip: List-type fields are almost always non-null lists with non-null
-elements. If you want a nullable list make sure there is real semantic value in
-being able to distinguish between an empty list and a null one.*
+`rules` は単純明快にルールのリストです。リスト自身とその要素がともに非Nullと示されていることに注意してください。GraphQLは`null`と`[]`、`[null]`のすべてを区別します。  
+手動コレクションについては、これらのリストが空になるかもしれませんが、Nullにはなりませんし、要素としてNullを含むこともありません。
 
-The second field is a bit weird: it is a boolean field indicating whether the
-rules apply disjunctively or not. It is also non-null, but here we run into a
-problem: what value should this field take for manual collections? Making it
-either false or true feels misleading, but making the field nullable then makes
-it a kind of weird tri-state flag which is also awkward when dealing with
-automatic collections. While we're puzzling over this, there is one other thing
-that is worth mentioning: these two fields are obviously and intricately related.
-This is true semantically, and it's also hinted by the fact that we chose names
-with a shared prefix. Is there a way to indicate this relationship in the schema
-somehow?
+*Protip: リスト型はほとんどいつもに非Nullで非Null要素しか含みません。
+Nullableなリストを使う場合は、本当にそれが空リストとNullを区別する必要があるのか確認しましょう。*
 
-As a matter of fact, we can solve all of these problems in one fell swoop by
-deviating even further from our underlying implementation and introducing a new
-GraphQL type with no direct model equivalent: `CollectionRuleSet`. This is often
-warranted when you have a set of closely-related fields whose values and
-behaviour are linked. By grouping the two fields into their own type at the API
-level we provide a clear semantic indicator and also solve all of our problems
-around nullability: for manual collections, it is the rule-set itself which is
-null. The boolean field can remain non-null. This leads us to the following
-design:
+２つめのフィールドはすこし厄介です。`rulesApplyDisjunctively`はルールを分けて適用すべきか否かを表すBooleanフィールドです。  
+非Nullと示されていますが、ここで問題に遭遇します。手動コレクションの場合にこのフィールドは一体どの値をもつべきでしょうか。  
+trueとfalseのいずれもミスリーディングのように感じますが、かといってNullableにしたところで３状態を表現するフラグは、自動コレクションの場合に違和感を覚えます。
+
+この問題のパズルを試してみるのもいいですが、他にももうひとつ考えるに値する方法があります。  
+これら２つのフィールドは明らかに密接に関連しています。意味的にも明らかですし、同じ接頭辞を用いているという事実からも確認できます。  
+どうにかして、この関係性をスキーマで表現する方法はないでしょうか？
+
+じつ言えば、詳細実装をさらに越えて考えることで、これらの問題を一度に解決できます。  
+詳細実装には直接相当するモデルがないかもしれませんが、GraphQLに新しい`CollectionRuleSet`型を追加するのです。
+
+値や振る舞いが密接に関連するフィールドの集まりがあるときにこの手法は有効です。  
+APIレベルにおいて複数のフィールドをまとめることで、意味的に明確な指針を提供でき、さらにNullabilityまつわる問題も解決できます。  
+手動コレクションではルールセット自体がNullになり、Booleanフィールドは非Nullのままです。
+APIは次のようになります。
 
 ```graphql
 type Collection implements Node {
@@ -328,12 +320,10 @@ type CollectionRule {
 }
 ```
 
-*Protip: Like lists, boolean fields are almost always non-null. If you want a
-nullable boolean, make sure there is real semantic value in being able to
-distinguish between all three states (null/false/true) and that it doesn't
-indicate a bigger design flaw.*
+*Protip: リストのように、Booleanもほとんどいつも非Nullです。*
+NullableなBooleanを使う場合は、本当に３状態（Null/false/true）を区別する必要があるのかという点と、設計上のより大きな問題を招かないことを確認ましょう。*
 
-*Rule #6: Group closely-related fields together into subobjects.*
+*ルール #6: 密接に関連する複数のフィールドはサブオブジェクトにまとめること。*
 
 ### Lists and Pagination
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -444,28 +444,29 @@ GraphQLは標準で十分なスカラー型（`String`, `Int`, `Boolean`など�
 
 ### Pagination Again
 
-That covers all of the fields in our core `Collection` type. The next object is
-`CollectionRuleSet`, which is quite simple. The only question here is whether or
-not the list of rules should be paginated. In this case the existing array
-actually makes sense; paginating the list of rules would be overkill. Most
-collections will only have a handful of rules, and there isn't a good use case
-for a collection to have a large rule set. Even a dozen rules is probably an
-indicator that you need to rethink that collection, or should just be manually
-adding products.
+これで`Collection`型のすべてのフィールドを確認しました。
+つぎのオブジェクトは非常にシンプルな`CollectionRuleSet`です。  
+
+唯一の懸念は、リストをページネーションするかどうかという点です。
+この場合には、ページネーションは手の込みすぎた実装でしょうから、現状のリスト定義のほうが適しています。
+ほとんどのコレクションは片手で数えられるほどのルールしか含むことはないですし、ひとつのコレクションに対して膨大なルールを設けることは好ましいユースケースではありません。
+
+たとえ数十のルールだとしても、それはコレクションの定義を考え直す兆候かもしれません。
+あるいは単に手動で商品を追加すれば済む話かもしれません。
 
 ### Enums
 
-This brings us to the final type in our schema, `CollectionRule`. Each rule
-consists of a column to match on (e.g. product title), a type of relation (e.g.
-equality) and an actual value to use (e.g. "Boots") which is confusingly called
-`condition`. That last field can be renamed, and so should `column`; column is
-very database-specific terminology, and we're working in GraphQL. `field` is
-probably a better choice.
+最後に残った型は`CollectionRule`です。
+それぞれのルールは、フィルタ対象のカラム（例えば商品名）、比較方法（例えば完全一致）、そして`condition`と呼ばれる紛らわしい比較対象値（例えば"Boots"）によって構成されます。
 
-As far as types go, both `field` and `relation` are probably implemented
-internally as enumerations (assuming your language of choice even has
-enumerations). Fortunately GraphQL has enums as well, so we can convert those
-two fields to enums. Our completed schema design now looks like this:
+`condition`と`column`のフィールド名は変更されて然るべきです。
+`column`という名前はデータベース固有の語用ですが、我々が考えているのはGraphQLです。  
+`field`のほうが良い選択でしょう。
+
+型に着目してみると、`field`と`relation`は内部的には列挙型で実装されているかもしれません（実装言語が列挙型を提供していると想定します。）  
+幸いなことにGraphQLもまた列挙型をもっていますので、それら２つのフィールドを列挙型に変更しましょう。
+
+完成したスキーマは以下のようになります。
 
 ```graphql
 type Collection implements Node {
@@ -509,7 +510,7 @@ enum CollectionRuleRelation {
 }
 ```
 
-*Rule #11: Use enums for fields which can only take a specific set of values.*
+*ルール #11: 特定の値しかとることがないなら列挙型を使うこと。*
 
 ## Step Four: Business Logic
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -1,4 +1,4 @@
-# Tutorial: Designing a GraphQL API
+# チュートリアル: GraphQL APIの設計
 
 本チュートリアルはもともと[Shopify](https://www.shopify.ca/)が社内向けに作成しました。
 そして、本チュートリアルがGraphQL APIを利用する全ての方にとって役に立つと考え、公開版を作成するに至りました。
@@ -10,12 +10,12 @@
 ほとんどのルールがつねに100%適用可能な訳ではないため、社内のなかでも未だに議論がありますし、例外を設けています。
 ですから、本チュートリアルに盲目的に従ってすべてを取り込もうとせず、あなたの目的や状況に応じて役に立つ部分を適用してください。
 
-## Intro
+## イントロダクション
 
 ようこそ！本ドキュメントでは、新しいGraphQL APIの（あるいは既存のGraphQL APIの拡張の）設計方法をみていきます。
 APIの設計は、反復的な改善、実験、ビジネスドメインの十分な理解が求められる挑戦的なタスクです。
 
-## Step Zero: Background
+## ステップ０: 背景
 
 本チュートリアルでは、あるE-コマース運営企業の開発業務を想定します。
 あなたはすでに商品情報を公開するための非常に小規模なGraphQL APIをもっています。
@@ -33,7 +33,7 @@ APIの設計は、反復的な改善、実験、ビジネスドメインの十�
 
 以上の背景をふまえ、APIデザインを考えていきます。
 
-## Step One: A Bird's-Eye View
+## ステップ１: 俯瞰的な視点
 
 素朴にスキーマを定義すると以下のようになります（`Product` など既存の型は省略します。）
 ```graphql
@@ -113,9 +113,9 @@ type CollectionMembership {
 このシンプルな表現ではすべての値フィールド、フィールド名、Null制約の情報を取り除いてあります。
 残ったものはGraphQLのように見える何かに過ぎませんが、型や関連性といった高いレベルで考えさせてくれます。
 
-*ルール #1: 詳細に取り掛かる前に、高いレベルでオブジェクトとそれらの関連性を考えることからはじめよ。*
+*ルール #1: 詳細に取り掛かる前に、高いレベルでオブジェクトとそれらの関連性を考えることからはじめること。*
 
-## Step Two: A Clean Slate
+## ステップ２: 白紙の状態
 
 それではこのシンプルな構造を用いて、当初の設計における主要な誤りをみていきましょう。
 
@@ -125,11 +125,11 @@ type CollectionMembership {
 このアプローチの根本的な問題は、APIは詳細実装とは異なる目的の振る舞いを持ち、また多くの場合は抽象度のレベルも異なることです。
 今回のケースでは、我々の詳細実装によって多くの迷いが生じました。
 
-### Representing `CollectionMembership`s
+### `CollectionMembership`の表現
 
-現状のスキーマに `CollectionMembership` が含まれていることに気がついたかもしれません。
-コレクションメンバーシップテーブルは商品とコレクションの間の他対他の関連を表現するために使われます。
-最後の部分をもう一度読んでください、「*商品とコレクションの間*」の関連とあります。
+現状のスキーマに`CollectionMembership`が含まれていることに気がついたかもしれません。
+コレクションメンバーシップテーブルは商品とコレクションの他対他の関連を表現するために使われます。
+最後の部分をもう一度読んでください、「*商品とコレクション*」の関連とあります。
 ビジネスドメインのセマンティクスからすれば、コレクションメンバーシップは意味を持っていないのです。
 コレクションメンバーシップは詳細実装です。
 
@@ -159,9 +159,9 @@ type AutomaticCollectionRule { }
 
 かなり良くなりました。
 
-*ルール #2: 詳細実装をAPI設計において表現してはならない。*
+*ルール #2: 詳細実装をAPI設計に含めないこと。*
 
-### Representing Collections
+### コレクションの表現
 
 ビジネスドメインの十分な理解がないと気づかないかもしれませんが、まだ今のAPI設計には大きな誤りがひとつ残されています。
 
@@ -192,7 +192,7 @@ type CollectionRule { }
 しかし、思い出してください、これは関連のリストなのです。
 我々のあたらしいAPI設計では、手動コレクションは単に選択ルールが無い（空）コレクションにすぎません。
 
-### Conclusion
+### 結論
 
 この抽象レベルにおけて最適なAPI設計を行うには、モデリング対象としているビジネスドメインへの深い理解が要求されます。
 ュートリアルの設定だけで特定の話題に関するコンテキストの深さをお伝えするのは困難ですが、本節のコレクション設計の例を通して、APIの設計方針を説明できていれば幸いです。
@@ -211,7 +211,7 @@ REST APIとGraphQLの背後にある設計思想はまったく異なった決�
 
 *ルール #3: 詳細実装でも、ユーザインタフェースでも、あるいはレガシーなAPIでもなく、ビジネスドメインに従ってAPI設計を行うこと。*
 
-## Step Three: Adding Detail
+## ステップ３: 詳細を詰める
 
 我々の型をモデリングするクリーンな構造を手に入れることができました。  
 もう一度、細部に視点を移して省いていたフィールドを追加していきましょう。
@@ -224,7 +224,7 @@ GraphQLにおいて要素を追加するという操作は簡単ですが、そ�
 
 *ルール #4: フィールドの追加操作は削除操作よりも簡単。*
 
-### Starting point
+### 出発点
 
 素朴な設計で存在していたフィールドを、我々の新しい構造に戻すと次のスキーマを得ます。
 
@@ -249,7 +249,7 @@ type CollectionRule {
 これが我々が解決すべき新しい問題です。
 上から順にフィールドをみていき、ひとつずつ解決していきましょう。
 
-### IDs and the `Node` Interface
+### IDと`Node`インターフェース
 
 まずはじめに、コレクション型のIDフィールドに注目します。  
 良さそうに見えます。IDはAPIを通してとくに変更や削除操作を行う際に、コレクションを特定するために使われます。
@@ -273,9 +273,9 @@ type Collection implements Node {
 }
 ```
 
-*ルール #5: 主要なビジネスオブジェクト型は`Node`インターフェースを実装する。*
+*ルール #5: 主要なビジネスオブジェクト型は`Node`インターフェースを実装すること。*
 
-### Rules and Subobjects
+### ルールとサブオブジェクト
 
 コレクション内の、つぎの２つのフィールド`rules`と`rulesApplyDisjunctively`をみていきましょう。  
 
@@ -287,7 +287,8 @@ Nullableなリストを使う場合は、本当にそれが空リストとNull�
 
 ２つめのフィールドはすこし厄介です。`rulesApplyDisjunctively`はルールを分けて適用すべきか否かを表すBooleanフィールドです。  
 非Nullと示されていますが、ここで問題に遭遇します。手動コレクションの場合にこのフィールドは一体どの値をもつべきでしょうか。  
-trueとfalseのいずれもミスリーディングのように感じますが、かといってNullableにしたところで３状態を表現するフラグは、自動コレクションの場合に違和感を覚えます。
+trueとfalseのいずれもミスリーディングのように感じます。
+かといってNullableにしたところで３状態を表現するフラグは、自動コレクションの場合に違和感を覚えます。
 
 この問題のパズルを試してみるのもいいですが、他にももうひとつ考えるに値する方法があります。  
 これら２つのフィールドは明らかに密接に関連しています。意味的にも明らかですし、同じ接頭辞を用いているという事実からも確認できます。  
@@ -328,7 +329,7 @@ NullableなBooleanを使う場合は、本当に３状態（Null/false/true）�
 
 *ルール #6: 密接に関連する複数のフィールドはサブオブジェクトにまとめること。*
 
-### Lists and Pagination
+### リストとページネーション
 
 つぎは`products`フィールドです。これは問題ないかもしれません。
 `CollectionMembership`型を取り除くことで、我々はすでに関連に関する問題を修正しました。
@@ -363,9 +364,9 @@ type PageInfo {
 }
 ```
 
-*ルール #7: リストフィールドについてはページネーションの必要有無を常に確認する。*
+*ルール #7: リストフィールドについてはページネーションの必要性を常に確認すること。*
 
-###  Strings
+### 文字列
 
 次に登場するのは`title`フィールドです。これは本当に現状のままで問題ないでしょう。  
 すべてのコレクションはタイトルを持っているはずなので、非Nullのシンプルな文字列型です。
@@ -374,7 +375,7 @@ type PageInfo {
 NullableなStringを使う場合は、存在しないこと(`null`)と、存在しているが空文字列(`""`)の状態について意味的に本当に差異があるか確認ましょう。*
 空文字列を”許容可能だが値が埋められていない”ものとし、Nullを”許容不可能”なものと考えることができます*
 
-### IDs and Relations
+### IDと関連
 
 さて、`imageId`フィールドに取り掛かりましょう。
 このフィールドは、RESTの思想をGraphQLに適用しようとしたときに何がおこるかを示す典型的な例です。
@@ -418,7 +419,7 @@ type CollectionRule {
 
 *ルール #8: IDフィールドの代わりとして常にオブジェクトの参照を使うこと。*
 
-### Naming and Scalars
+### 命名とスカラー
 
 `Collection`型の最後のフィールドは`bodyHtml`です。  
 これはコレクションに対する説明文です。
@@ -445,7 +446,7 @@ GraphQLは標準で十分なスカラー型（`String`, `Int`, `Boolean`など�
 
 *ルール #10: 特定の意味を持った値を表現する場合にはカスタムスカラー型を使うこと。*
 
-### Pagination Again
+### 再びページネーション
 
 これで`Collection`型のすべてのフィールドを確認しました。
 つぎのオブジェクトは非常にシンプルな`CollectionRuleSet`です。  
@@ -457,7 +458,7 @@ GraphQLは標準で十分なスカラー型（`String`, `Int`, `Boolean`など�
 たとえ数十のルールだとしても、それはコレクションの定義を考え直す兆候かもしれません。
 あるいは単に手動で商品を追加すれば済む話かもしれません。
 
-### Enums
+### 列挙型
 
 最後に残った型は`CollectionRule`です。
 それぞれのルールは、フィルタ対象のカラム（例えば商品名）、比較方法（例えば完全一致）、そして`condition`と呼ばれる紛らわしい比較対象値（例えば"Boots"）によって構成されます。
@@ -513,9 +514,9 @@ enum CollectionRuleRelation {
 }
 ```
 
-*ルール #11: 特定の値しかとることがないなら列挙型を使うこと。*
+*ルール #11: 特定の値しかとることがなければ列挙型を使うこと。*
 
-## Step Four: Business Logic
+## ステップ４: ビジネスロジック
 
 さて、これでコレクションに対する最小かつ良く設計されたGraphQL APIが得られました。  
 まだ手を付けていないコレクションの詳細部分がありますが（商品の並び順や公開・非公開のの管理のためにまだ多くのフィールドが必要でしょう）、それら全てが等しく従うであろう設計パターンはすでに見てきました。  
@@ -534,8 +535,7 @@ enum CollectionRuleRelation {
 ほとんどの場合でAPIは複数のクライアントに対して提供されます。
 もしそれぞれのクライアントが同じロジックを実装しなければならないとしたら、それはコードの重複を生み、不必要なタスクとエラーが発生させる余地を伴います。
 
-*ルール #12: APIはデータだけではなくビジネスロジックを提供すべき。
-複雑な計算はサーバーで為されるべきで、複数のクライアントではない。*
+*ルール #12: APIはデータだけではなくビジネスロジックを提供すること。複雑な計算はサーバーで為されるべきで、複数のクライアントではない。*
 
 クライアントのユースケースに戻りましょう。ここでの最適解は、商品の所属有無判定を解決する専用のフィールドを設けることです。
 具体的にはこのような定義になるでしょう。
@@ -563,7 +563,7 @@ GraphQLはクライアントから明示的に要求されたものだけを返�
 ビジネスドメインのデータは依然としてコアモデルだということに変わりはありません。
 もしビジネスロジックのフィールドがどうしてもフィットしないと感じているなら、それは背後にあるモデル自体が正しくないことを示すサインかもしれません。
 
-## Step Five: Mutations
+## ステップ５: Mutations
 
 我々のGraphQLスキーマに足りていない最後のピースはデータを変更する機能です。
 コレクションを追加、変更したり、コレクションと関連するオブジェクトを削除するといった操作です。
@@ -572,7 +572,7 @@ GraphQLはクライアントから明示的に要求されたものだけを返�
 素朴にCRUD操作のパラダイムに従い、`create`、`delete`、そして`update`操作のmutationを設けてみます。
 これは議論を始めるにはちょうど良いものの、正しいGraphQL APIとしては不十分です。
 
-### Separate Logical Actions
+### 論理的なアクションの分割
 
 CRUDに従おうとすると、すぐに`update`が巨大になるということにまず気付くと思います。
 タイトルのようなシンプルなスカラー値を更新するだけではなく、コレクションの公開や非公開、商品の追加/削除/並べ替え操作、自動コレクションのルールの変更といったあらゆる複雑な操作がupdateの責任範囲となります。
@@ -588,7 +588,7 @@ CRUDに従おうとすると、すぐに`update`が巨大になるというこ�
 
 *ルール #14: リソースに対するロジックの異なる操作にはそれぞれmutationを用意すること。*
 
-### Manipulating Relationships
+### 関連の操作
 
 `update` mutationは依然として大きすぎる責務を負っているため、引き続き分解を進めましょう。
 とはいえ、分解した操作もそれぞれ別の次元（例えば１対多や多対多の関係性に関する操作）から考えてみる価値があるので、後ほど順に見ていきます。
@@ -641,7 +641,7 @@ mutationにおいても類似する問題に対処しなければなりません
 
 *ルール #16: 関連に対するmutationを分けて実装するときには、一度に複数の要素に対して実行することが便利かどうか検討すること。*
 
-### Input: Structure, Part 1
+### 入力: 構造 パート１
 
 さて、これで我々がどのようなmutationが必要なのかが分かりました。
 つぎは入力の型を明らかにしていきます。
@@ -694,7 +694,7 @@ input CollectionRuleInput {
 
 *ルール #17: アルファベット順でグループ化するために、mutationの接頭辞に操作対象のオブジェクト名を用いること（例えば`cancelOrder`ではなく`orderCancel`とする。）*
 
-### Input: Scalars
+### 入力: スカラー
 
 GraphQLの草案は素朴なものよりもかなり良くなっていますが、まだ完全ではありません。
 とくに`description`入力フィールドはいくつか問題をかかえています。
@@ -719,8 +719,7 @@ GraphQLの草案は素朴なものよりもかなり良くなっていますが�
 処理を簡単にするために、クライアント側で事前に検証を行うことが難しい場合には、我々は入力対して意図的に弱い型付けを行います。
 これにより、ビジネスロジックレイヤーがすべての検証を行い、クライアントも一箇所から発生するエラーだけに対処するだけで済みます。
 
-*ルール #19: フォーマットが曖昧であったり、クライアント側の検証が複雑な場合には、入力に対して弱い型付け（`Email`ではなく`String`）を行うこと。
- これによりサーバーは一度にすべての検証を実行し、単一のフォーマットでエラーを報告することになり、結果としてクライアント非常にシンプルになる。*
+*ルール #19: フォーマットが曖昧であったり、クライアント側の検証が複雑な場合には、入力に対して弱い型付け（`Email`ではなく`String`）を行うこと。これによりサーバーは一度にすべての検証を実行し、単一のフォーマットでエラーを報告することになり、結果としてクライアント非常にシンプルになる。*
 
 これはすべての入力に対して弱い型付けを推奨している訳ではないことに注意してください。
 我々はroleの入力における`field`と`relation`フィールドに強い型付けをもったenumを用いています。
@@ -731,10 +730,9 @@ HTMLはうまく定義されていて、明瞭な仕様がありますが、検�
 他方で日時や日付を表現する文字列には何百の表現方法があり、それらすべてが適切にシンプルなフォーマットをもっています。
 したがって、サーバーが期待するフォーマットを指定するために強い型付けを行うと便利です。
 
-*ルール #20: フォーマットが曖昧でクライアント側検証がシンプルな場合は強い型付け（`String`ではなく`DateTime`）を行うこと。
- 型付けにより明確さを得られ、クライアントにより厳しい入力値管理（フリーテキスト入力ではなくカレンダーウィジェットを用いる）を促します。*
+*ルール #20: フォーマットが曖昧でクライアント側検証がシンプルな場合は強い型付け（`String`ではなく`DateTime`）を行うこと。型付けにより明確さを得られ、クライアントにより厳しい入力値管理（フリーテキスト入力ではなくカレンダーウィジェットを用いる）を促せる。*
 
-### Input: Structure, Part 2
+### 入力: 構造 パート２
 
 つづいてupdate操作をみていきます。
 
@@ -779,7 +777,7 @@ input CollectionInput {
 
 *ルール #21: たとえいくつかのフィールドの必須制約を緩和する必要があっても、重複を減らすためにmutationの入力を構造化すること。*
 
-### Output
+### 出力
 
 設計に関する問題で最後に扱うのはmutationの戻り値です。
 基本的にmutationは実行結果として成功か、さもなくば失敗に到達します。
@@ -805,8 +803,7 @@ type UserError {
 処理に成功したmutationは空リストの`userErrors`と、`collection`フィールドには新たに作成されたコレクションを入れて返します。
 処理に失敗したmutationはひとつ以上の`UserError`オブジェクトを含むリストと、コレクションには`nil`を入れて返します。
 
-*ルール #22: mutationはビジネスロジックレベルのエラーを`userErrors`フィールドに入れて返すこと。
-トップレベルのエラーフィールドはクライアントおよびサーバーレベルのエラーのために残しておくこと。*
+*ルール #22: mutationはビジネスロジックレベルのエラーを`userErrors`フィールドに入れて返すこと。トップレベルのエラーフィールドはクライアントおよびサーバーレベルのエラーのために残しておくこと。*
 
 多くの実装においてこの構造の大半は自動的に提供されます。
 そのため、ここで為すべきは`collection`フィールドを定義することです。
@@ -827,30 +824,29 @@ type CollectionUpdatePayload {
 
 ## TLDR: The rules
 
-- Rule #1: Always start with a high-level view of the objects and their relationships before you deal with specific fields.
-- Rule #2: Never expose implementation details in your API design.
-- Rule #3: Design your API around the business domain, not the implementation, user-interface, or legacy APIs.
-- Rule #4: It’s easier to add fields than to remove them.
-- Rule #5: Major business-object types should always implement Node.
-- Rule #6: Group closely-related fields together into subobjects.
-- Rule #7: Always check whether list fields should be paginated or not.
-- Rule #8: Always use object references instead of ID fields.
-- Rule #9: Choose field names based on what makes sense, not based on the implementation or what the field is called in legacy APIs.
-- Rule #10: Use custom scalar types when you’re exposing something with specific semantic value.
-- Rule #11: Use enums for fields which can only take a specific set of values.
-- Rule #12: The API should provide business logic, not just data. Complex calculations should be done on the server, in one place, not on the client, in many places.
-- Rule #13: Provide the raw data too, even when there’s business logic around it.
-- Rule #14: Write separate mutations for separate logical actions on a resource.
-- Rule #15: Mutating relationships is really complicated and not easily summarized into a snappy rule.
-- Rule #16: When writing separate mutations for relationships, consider whether it would be useful for the mutations to operate on multiple elements at once.
-- Rule #17: Prefix mutation names with the object they are mutating for
- alphabetical grouping (e.g. use `orderCancel` instead of `cancelOrder`).
-- Rule #18: Only make input fields required if they're actually semantically required for the mutation to proceed.
-- Rule #19: Use weaker types for inputs (e.g. String instead of Email) when the format is unambiguous and client-side validation is complex. This lets the server run all non-trivial validations at once and return the errors in a single place in a single format, simplifying the client.
-- Rule #20: Use stronger types for inputs (e.g. DateTime instead of String) when the format may be ambiguous and client-side validation is simple. This provides clarity and encourages clients to use stricter input controls (e.g. a date-picker widget instead of a free-text field).
-- Rule #21: Structure mutation inputs to reduce duplication, even if this requires relaxing requiredness constraints on certain fields.
-- Rule #22: Mutations should provide user/business-level errors via a userErrors field on the mutation payload. The top-level query errors entry is reserved for client and server-level errors.
-- Rule #23: Most payload fields for a mutation should be nullable, unless there is really a value to return in every possible error case.
+- ルール #1: 詳細に取り掛かる前に、高いレベルでオブジェクトとそれらの関連性を考えることからはじめること。
+- ルール #2: 詳細実装をAPI設計に含めないこと。
+- ルール #3: 詳細実装でも、ユーザインタフェースでも、あるいはレガシーなAPIでもなく、ビジネスドメインに従ってAPI設計を行うこと。
+- ルール #4: フィールドの追加操作は削除操作よりも簡単。
+- ルール #5: 主要なビジネスオブジェクト型は`Node`インターフェースを実装すること。
+- ルール #6: 密接に関連する複数のフィールドはサブオブジェクトにまとめること。
+- ルール #7: リストフィールドについてはページネーションの必要性を常に確認すること。
+- ルール #8: IDフィールドの代わりとして常にオブジェクトの参照を使うこと。
+- ルール #9: 歴史的経緯や詳細実装ではなく、意味のある概念に基づいてフィールド名を選ぶこと。
+- ルール #10: 特定の意味を持った値を表現する場合にはカスタムスカラー型を使うこと。
+- ルール #11: 特定の値しかとることがなければ列挙型を使うこと。
+- ルール #12: APIはデータだけではなくビジネスロジックを提供すること。複雑な計算はサーバーで為されるべきで、複数のクライアントではない。
+- ルール #13: ビジネスロジックによって済まされる場合でも、元データを提供すること。
+- ルール #14: リソースに対するロジックの異なる操作にはそれぞれmutationを用意すること。
+- ルール #15: 関連に対する操作は複雑で、ひとつの便利な指針で語ることはできない。
+- ルール #16: 関連に対するmutationを分けて実装するときには、一度に複数の要素に対して実行することが便利かどうか検討すること。
+- ルール #17: アルファベット順でグループ化するために、mutationの接頭辞に操作対象のオブジェクト名を用いること（例えば`cancelOrder`ではなく`orderCancel`とする。）
+- ルール #18: mutation処理を遂行するうえで意味的に本当に必要である場合に限り、入力フィールドを必須とすること。
+- ルール #19: フォーマットが曖昧であったり、クライアント側の検証が複雑な場合には、入力に対して弱い型付け（`Email`ではなく`String`）を行うこと。これによりサーバーは一度にすべての検証を実行し、単一のフォーマットでエラーを報告することになり、結果としてクライアント非常にシンプルになる。
+- ルール #20: フォーマットが曖昧でクライアント側検証がシンプルな場合は強い型付け（`String`ではなく`DateTime`）を行うこと。型付けにより明確さを得られ、クライアントにより厳しい入力値管理（フリーテキスト入力ではなくカレンダーウィジェットを用いる）を促せる。
+- ルール #21: たとえいくつかのフィールドの必須制約を緩和する必要があっても、重複を減らすためにmutationの入力を構造化すること。
+- ルール #22: mutationはビジネスロジックレベルのエラーを`userErrors`フィールドに入れて返すこと。トップレベルのエラーフィールドはクライアントおよびサーバーレベルのエラーのために残しておくこと。
+- ルール #23: すべてのエラーケースおいて返せる特定の値がないのであれば、mutationが返すほとんどのフィールドはNullableであること。
 
 ## Conclusion
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -1,16 +1,19 @@
 # Tutorial: Designing a GraphQL API
 
-本チュートリアルは[Shopify](https://www.shopify.ca/)によって社内向けに作られました。
-我々は本チュートリアルがGraphQL APIを利用する全ての方にとって役に立つと考え、公開版を作成するに至りました。
+本チュートリアルはもともと[Shopify](https://www.shopify.ca/)が社内向けに作成しました。
+そして、本チュートリアルがGraphQL APIを利用する全ての方にとって役に立つと考え、公開版を作成するに至りました。
 
-本チュートリアルは、Shopifyのプロダクション環境における過去３年間のスキーマ構築と発展から得た学びに基づいています。
+本チュートリアルは、Shopifyのプロダクション環境における過去３年間のスキーマ構築と拡張から得た学びに基づいています。
 本チュートリアルはこれまでも発展してきましたし、今後も更新され続けるでしょう。
+
+我々は本デザインガイドラインが多くの場合に有用であると信じていますが、すべてがあらゆる状況に当てはまるとは限りません。
+ほとんどのルールがつねに100%適用可能な訳ではないため、社内のなかでも未だに議論がありますし、例外を設けています。
 ですから、本チュートリアルに盲目的に従ってすべてを取り込もうとせず、あなたの目的や状況に応じて役に立つ部分を適用してください。
 
 ## Intro
 
 ようこそ！本ドキュメントでは、新しいGraphQL APIの（あるいは既存のGraphQL APIの拡張の）設計方法をみていきます。
-APIの設計は、繰り返し、実験し、ビジネスドメインの十分な理解を得るに値する挑戦的な仕事です。
+APIの設計は、反復的な改善、実験、ビジネスドメインの十分な理解が求められる挑戦的なタスクです。
 
 ## Step Zero: Background
 
@@ -818,7 +821,7 @@ type CollectionUpdatePayload {
 ```
 
 ここでも依然として`collection`がNullableになっていることに注目してください。
-有効なコレクションのIDが渡されない場合には、返すべきコレクションがありません。
+渡されたものが有効なコレクションのIDでなかった場合、返すべきコレクションがないからです。
 
 *ルール #23: すべてのエラーケースおいて返せる特定の値がないのであれば、mutationが返すほとんどのフィールドはNullableであること。*
 
@@ -851,7 +854,7 @@ type CollectionUpdatePayload {
 
 ## Conclusion
 
-Thank you for reading our tutorial! Hopefully by this point you have a solid
-idea of how to design a good GraphQL API.
+我々のチュートリアルを読んでいただきありがとうございました！
+GraphQL APIの良いデザインに関する有用なアイディアを持ち帰っていただければ幸いです。
 
-Once you've designed an API you're happy with, it's time to implement it!
+満足のいくデザインができたら、あとは実装するだけです！

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -327,26 +327,21 @@ NullableなBooleanを使う場合は、本当に３状態（Null/false/true）�
 
 ### Lists and Pagination
 
-Next on the chopping block is our `products` field. This one might seem safe;
-after all we already "fixed" this relation back when we removed our `CollectionMembership`
-type, but in fact there's something else wrong here.
+つぎは`products`フィールドです。これは問題ないかもしれません。
+`CollectionMembership`型を取り除くことで、我々はすでに関連に関する問題を修正しました。
+しかし、じつは他にも良くない点があります。
 
-The field as currently defined returns an array of products, but collections can
-easily have many tens of thousands of products, and trying to gather all of
-those into a single array would be incredibly expensive and inefficient. For
-situations like this, GraphQL provides lists pagination.
+本フィールドは現状では商品の配列として定義されていますが、やがてコレクションは何千という商品を含むようになり、一度にすべての商品を取得するのは驚くほどコストがかかり非効率的になるでしょう。
+このような状況のために、GraphQLはリストページネーションを提供しています。
 
-Whenever you implement a field or relation returning multiple objects, always
-ask yourself if the field should be paginated or not. How many of this object
-can there be? What quantity is considered pathological?
+複数のオブジェクトを返すフィールドや関連を実装する際は、ページネーションが必要かどうかいつも自問自答するようにしましょう。
+どのくらいの量のオブジェクトがありえるのでしょうか？どの程度であれば例外とみなせるのでしょうか？
 
-Paginating a field means you need to implement a pagination solution first.
-This tutorial uses [Connections](https://graphql.org/learn/pagination/#complete-connection-model)
-which is defined by the [Relay Connection spec](https://facebook.github.io/relay/graphql/connections.htm).
+ページネーションフィールドを利用するには、そもそもページネーションのための実装も必要となります。
+本チュートリアルでは[Relay Connection spec](https://facebook.github.io/relay/graphql/connections.htm)で定義される[Connections](https://graphql.org/learn/pagination/#complete-connection-model)を用います。
 
-In this case, paginating the products field in our design is as simple as
-changing its definition to `products: ProductConnection!`. Assuming you have
-connections implemented, your types would look like this:
+今回の場合、商品フィールドをページネーションさせるには、型の定義を`products: ProductConnection!`に変更すればよいでしょう。
+すでに実装が済んでいれば、APIデザインは次のようになります。
 
 ```graphql
 type ProductConnection {
@@ -365,8 +360,7 @@ type PageInfo {
 }
 ```
 
-
-*Rule #7: Always check whether list fields should be paginated or not.*
+*ルール #7: リストフィールドについてはページネーションの必要有無を常に確認する。*
 
 ###  Strings
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -1,0 +1,976 @@
+# Tutorial: Designing a GraphQL API
+
+本チュートリアルは[Shopify](https://www.shopify.ca/)によって社内向けに作られました。
+我々は本チュートリアルがGraphQL APIを利用する全ての方にとって役に立つと考え、公開版を作成するに至りました。
+
+本チュートリアルは、Shopifyのプロダクション環境における過去３年間のスキーマ構築と発展から得た学びに基づいています。
+本チュートリアルはこれまでも発展してきましたし、今後も更新され続けるでしょう。
+ですから、本チュートリアルに盲目的に従ってすべてを取り込もうとせず、あなたの目的や状況に応じて役に立つ部分を適用してください。
+
+## Intro
+
+ようこそ！本ドキュメントでは、新しいGraphQL APIの（あるいは既存のGraphQL APIの拡張の）設計方法をみていきます。
+APIの設計は、繰り返し、実験し、ビジネスドメインの十分な理解を得るに値する挑戦的な仕事です。
+
+## Step Zero: Background
+
+本チュートリアルでは、あるE-コマース運営企業の開発業務を想定します。
+あなたはすでに商品情報を公開するための非常に小規模なGraphQL APIをもっています。
+あなたのチームは、ちょうどコレクション機能のバックエンド部分の実装を終え、本機能をAPIで公開したいと考えています。
+
+コレクションは新しい主要機能で商品をグループにまとめることができます。
+例えばあなたの所有するすべてのTシャツ商品をまとめたコレクションが考えられます。
+コレクションはWebサイトにおいて商品をまとめて表示する際に利用できますし、自動化タスクにも利用できます（特定のコレクションの商品に対してのみ、ある割引価格と適用したい場合など。）
+
+バックエンドではコレクション機能は以下のように実装されました。
+- すべてのコレクションは、タイトルや説明文（HTMLを含むかもしれません）、画像などのいくつかの属性をもちます。
+- コレクションは２種類に分けられます。"手動"コレクションは自分で商品を登録し、"自動"コレクションはいくつかのルールを設定することで自動的に商品が登録されます。
+- 商品とコレクションは、中間テーブル `CollectionMembership` を通して他対他のリレーションを持ちます。
+- コレクションと商品は公開（店頭に並んでいる）と非公開のいずれかの状態にあります。
+
+以上の背景をふまえ、APIデザインを考えていきます。
+
+## Step One: A Bird's-Eye View
+
+A naive version of the schema might look something like this (leaving out all
+the pre-existing types like `Product`):
+```graphql
+interface Collection {
+  id: ID!
+  memberships: [CollectionMembership!]!
+  title: String!
+  imageId: ID
+  bodyHtml: String
+}
+
+type AutomaticCollection implements Collection {
+  id: ID!
+  rules: [AutomaticCollectionRule!]!
+  rulesApplyDisjunctively: Bool!
+  memberships: [CollectionMembership!]!
+  title: String!
+  imageId: ID
+  bodyHtml: String
+}
+
+type ManualCollection implements Collection {
+  id: ID!
+  memberships: [CollectionMembership!]!
+  title: String!
+  imageId: ID
+  bodyHtml: String
+}
+
+type AutomaticCollectionRule {
+  column: String!
+  relation: String!
+  condition: String!
+}
+
+type CollectionMembership {
+  collectionId: ID!
+  productId: ID!
+}
+```
+
+This is already decently complicated at a glance, even though it's only four
+objects and an interface. It also clearly doesn't implement all of the features
+that we would need if we're going to be using this API to build out e.g. our
+mobile app's collection feature.
+
+Let's take a step back. A decently complex GraphQL API will consist of many
+objects, related via multiple paths and with dozens of fields. Trying to design
+something like this all at once is a recipe for confusion and mistakes. Instead,
+you should start with a higher-level view first, focusing on just the types and
+their relations without worrying about specific fields or mutations.
+Basically think of an [Entity-Relationship model](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model)
+but with a few GraphQL-specific bits thrown in. If we shrink our naive schema
+down like that, we end up with the following:
+
+```graphql
+interface Collection {
+  Image
+  [CollectionMembership]
+}
+
+type AutomaticCollection implements Collection {
+  [AutomaticCollectionRule]
+  Image
+  [CollectionMembership]
+}
+
+type ManualCollection implements Collection {
+  Image
+  [CollectionMembership]
+}
+
+type AutomaticCollectionRule { }
+
+type CollectionMembership {
+  Collection
+  Product
+}
+```
+
+To get this simplified representation, I took out all scalar fields, all field
+names, and all nullability information. What you're left with still looks kind
+of like GraphQL but lets you focus on higher level of the types and their
+relationships.
+
+*Rule #1: Always start with a high-level view of the objects and their
+relationships before you deal with specific fields.*
+
+## Step Two: A Clean Slate
+
+Now that we have something simple to work with, we can address the major flaws
+with this design.
+
+As previously mentioned, our implementation defines the existence of manual and
+automatic collections, as well as the use of a collector join table. Our naive
+API design was clearly structured around our implementation, but this was a
+mistake.
+
+The root problem with this approach is that an API operates for a different
+purpose than an implementation, and frequently at a different level of
+abstraction. In this case, our implementation has led us astray on a number of
+different fronts.
+
+### Representing `CollectionMembership`s
+
+The one that may have stood out to you already, and is hopefully fairly obvious,
+is the inclusion of the `CollectionMembership` type in the schema. The collection memberships table is
+used to represent the many-to-many relationship between products and collections.
+Now read that last sentence again: the relationship is *between products and
+collections*; from a semantic, business domain perspective, collection memberships have
+nothing to do with anything. They are an implementation detail.
+
+This means that they don't belong in our API. Instead, our API should expose the
+actual business domain relationship to products directly. If we take out
+collection memberships, the resulting high-level design now looks like:
+
+```graphql
+interface Collection {
+  Image
+  [Product]
+}
+
+type AutomaticCollection implements Collection {
+  [AutomaticCollectionRule]
+  Image
+  [Product]
+}
+
+type ManualCollection implements Collection {
+  Image
+  [Product]
+}
+
+type AutomaticCollectionRule { }
+```
+
+This is much better.
+
+*Rule #2: Never expose implementation details in your API design.*
+
+### Representing Collections
+
+This API design still has one major flaw, though it's one that's probably much
+less obvious without a really thorough understanding of the business domain. In
+our existing design, we model AutomaticCollections and ManualCollections as two
+different types, each implementing a common Collection interface. Intuitively
+this makes a fair bit of sense: they have a lot of common fields, but are
+still distinctly different in their relationships (AutomaticCollections have
+rules) and some of their behaviour.
+
+But from a business model perspective, these differences are also basically an
+implementation detail. The defining behaviour of a collection is that it groups
+products; the method of choosing those products is secondary. We could expand
+our implementation at some point to permit some third method of choosing
+products (machine learning?) or to permit mixing methods (some rules and some
+manually added products) and *they would still just be collections*. You could
+even argue that the fact we don't permit mixing right now is an implementation
+failure. All of this to say is that the shape of our API should really look more
+like this:
+
+```graphql
+type Collection {
+  [CollectionRule]
+  Image
+  [Product]
+}
+
+type CollectionRule { }
+```
+
+That's really nice. The immediate concern you may have at this point is that
+we're now pretending ManualCollections have rules, but remember that this
+relationship is a list. In our new API design, a "ManualCollection" is just a
+Collection whose list of rules is empty.
+
+### Conclusion
+
+Choosing the best API design at this level of abstraction necessarily requires
+you to have a very deep understanding of the problem domain you're modeling.
+It's hard in a tutorial setting to provide that depth of context for a specific
+topic, but hopefully the collection design is simple enough that the reasoning
+still makes sense. Even if you don't have this depth of understanding
+specifically for collections, you still absolutely need it for whatever domain
+you're actually modeling. It is critically important when designing your API
+that you ask yourself these tough questions, and don't just blindly follow the
+implementation.
+
+On a closely related note, a good API does not model the user interface either.
+The implementation and the UI can both be used for inspiration and input into
+your API design, but the final driver of your decisions must always be the
+business domain.
+
+Even more importantly, existing REST API choices should not necessarily be
+copied. The design principles behind REST and GraphQL can lead to very different
+choices, so don't assume that what worked for your REST API is a good choice for
+GraphQL.
+
+As much as possible let go of your baggage and start from scratch.
+
+*Rule #3: Design your API around the business domain, not the implementation,
+user-interface, or legacy APIs.*
+
+## Step Three: Adding Detail
+
+Now that we have a clean structure to model our types, we can add back our
+fields and start to work at that level of detail again.
+
+Before we start adding detail, ask yourself if it's really needed at this
+time. Just because a database column, model property, or REST attribute may
+exist, doesn't mean it automatically needs to be added to the GraphQL schema.
+
+Exposing a schema element (field, argument, type, etc) should be driven by an
+actual need and use case. GraphQL schemas can easily be evolved by adding
+elements, but changing or removing them are breaking changes and much more
+difficult.
+
+*Rule #4: It's easier to add fields than to remove them.*
+
+### Starting point
+
+Restoring our naive fields adjusted for our new structure, we get:
+
+```graphql
+type Collection {
+  id: ID!
+  rules: [CollectionRule!]!
+  rulesApplyDisjunctively: Bool!
+  products: [Product!]!
+  title: String!
+  imageId: ID
+  bodyHtml: String
+}
+
+type CollectionRule {
+  column: String!
+  relation: String!
+  condition: String!
+}
+```
+
+Now we have a whole new host of design problems to resolve. We'll work through
+the fields in order top to bottom, fixing things as we go.
+
+### IDs and the `Node` Interface
+
+The very first field in our Collection type is an ID field, which is fine and
+normal; this ID is what we'll need to use to identify our collections throughout
+the API, in particular when performing actions like modifying or deleting them.
+However there is one piece missing from this part of our design: the `Node`
+interface. This is a very commonly-used interface that already exists in most
+schemas and looks like this:
+```graphql
+interface Node {
+  id: ID!
+}
+```
+It hints to the client that this object is persisted and retrievable by the
+given ID, which allows the client to accurately and efficiently manage local
+caches and other tricks. Most of your major identifiable business objects
+(e.g. products, collections, etc) should implement `Node`.
+
+The beginning of our design now just looks like:
+```graphql
+type Collection implements Node {
+  id: ID!
+}
+```
+
+*Rule #5: Major business-object types should always implement `Node`.*
+
+### Rules and Subobjects
+
+We will consider the next two fields in our Collection type together: `rules`,
+and `rulesApplyDisjunctively`. The first is pretty straightforward: a list of
+rules. Do note that both the list itself and the elements of the list are marked
+as non-null: this is fine, as GraphQL does distinguish between `null` and `[]`
+and `[null]`. For manual collections, this list can be empty, but it cannot be
+null nor can it contain a null.
+
+*Protip: List-type fields are almost always non-null lists with non-null
+elements. If you want a nullable list make sure there is real semantic value in
+being able to distinguish between an empty list and a null one.*
+
+The second field is a bit weird: it is a boolean field indicating whether the
+rules apply disjunctively or not. It is also non-null, but here we run into a
+problem: what value should this field take for manual collections? Making it
+either false or true feels misleading, but making the field nullable then makes
+it a kind of weird tri-state flag which is also awkward when dealing with
+automatic collections. While we're puzzling over this, there is one other thing
+that is worth mentioning: these two fields are obviously and intricately related.
+This is true semantically, and it's also hinted by the fact that we chose names
+with a shared prefix. Is there a way to indicate this relationship in the schema
+somehow?
+
+As a matter of fact, we can solve all of these problems in one fell swoop by
+deviating even further from our underlying implementation and introducing a new
+GraphQL type with no direct model equivalent: `CollectionRuleSet`. This is often
+warranted when you have a set of closely-related fields whose values and
+behaviour are linked. By grouping the two fields into their own type at the API
+level we provide a clear semantic indicator and also solve all of our problems
+around nullability: for manual collections, it is the rule-set itself which is
+null. The boolean field can remain non-null. This leads us to the following
+design:
+
+```graphql
+type Collection implements Node {
+  id: ID!
+  ruleSet: CollectionRuleSet
+  products: [Product!]!
+  title: String!
+  imageId: ID
+  bodyHtml: String
+}
+
+type CollectionRuleSet {
+  rules: [CollectionRule!]!
+  appliesDisjunctively: Bool!
+}
+
+type CollectionRule {
+  column: String!
+  relation: String!
+  condition: String!
+}
+```
+
+*Protip: Like lists, boolean fields are almost always non-null. If you want a
+nullable boolean, make sure there is real semantic value in being able to
+distinguish between all three states (null/false/true) and that it doesn't
+indicate a bigger design flaw.*
+
+*Rule #6: Group closely-related fields together into subobjects.*
+
+### Lists and Pagination
+
+Next on the chopping block is our `products` field. This one might seem safe;
+after all we already "fixed" this relation back when we removed our `CollectionMembership`
+type, but in fact there's something else wrong here.
+
+The field as currently defined returns an array of products, but collections can
+easily have many tens of thousands of products, and trying to gather all of
+those into a single array would be incredibly expensive and inefficient. For
+situations like this, GraphQL provides lists pagination.
+
+Whenever you implement a field or relation returning multiple objects, always
+ask yourself if the field should be paginated or not. How many of this object
+can there be? What quantity is considered pathological?
+
+Paginating a field means you need to implement a pagination solution first.
+This tutorial uses [Connections](https://graphql.org/learn/pagination/#complete-connection-model)
+which is defined by the [Relay Connection spec](https://facebook.github.io/relay/graphql/connections.htm).
+
+In this case, paginating the products field in our design is as simple as
+changing its definition to `products: ProductConnection!`. Assuming you have
+connections implemented, your types would look like this:
+
+```graphql
+type ProductConnection {
+  edges: [ProductEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ProductEdge {
+  cursor: String!
+  node: Product!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+```
+
+
+*Rule #7: Always check whether list fields should be paginated or not.*
+
+###  Strings
+
+Next up is the `title` field. This one is legitimately fine the way it is. It's
+a simple string, and it's marked non-null because all collections must have a
+title.
+
+*Protip: As with booleans and lists, it's worth noting that GraphQL does
+distinguish between empty strings (`""`) and nulls (`null`), so if you need a
+nullable string make sure there is a legitimate semantic difference between
+not-present (`null`) and present-but-empty (`""`). You can often think of empty
+strings as meaning "applicable, but not populated", and null strings meaning
+"not applicable".*
+
+### IDs and Relations
+
+Now we come to the `imageId` field. This field is a classic example of what
+happens when you try and apply REST designs to GraphQL. In REST APIs it's
+pretty common to include the IDs of other objects in your response as a way to
+link together those objects, but this is a major anti-pattern in GraphQL.
+Instead of providing an ID, and forcing the client to do another round-trip to
+get any information on the object, we should just include the object directly
+into the graph - that's what GraphQL is for after all. In REST APIs this pattern
+often isn't practical, since it inflates the size of the response significantly
+when the included objects are large. However, this works fine in GraphQL because
+every field must be explicitly queried or the server won't return it.
+
+As a general rule, the only ID fields in your design should be the IDs of the
+object itself. Any time you have some other ID field, it should probably be an
+object reference instead. Applying this to our schema so far, we get:
+
+```graphql
+type Collection implements Node {
+  id: ID!
+  ruleSet: CollectionRuleSet
+  products: ProductConnection!
+  title: String!
+  image: Image
+  bodyHtml: String
+}
+
+type Image {
+  id: ID!
+}
+
+type CollectionRuleSet {
+  rules: [CollectionRule!]!
+  appliesDisjunctively: Bool!
+}
+
+type CollectionRule {
+  column: String!
+  relation: String!
+  condition: String!
+}
+```
+
+*Rule #8: Always use object references instead of ID fields.*
+
+### Naming and Scalars
+
+The last field in our simple `Collection` type is `bodyHtml`. To a user who is
+unfamiliar with the way that collections were implemented, it's not entirely
+obvious what this field is for; it's the body description of the specific
+collection. The first thing we can do to make this API better is just to rename
+it to `description`, which is a much clearer name.
+
+*Rule #9: Choose field names based on what makes sense, not based on the
+implementation or what the field is called in legacy APIs.*
+
+Next, we can make it non-nullable. As we talked about with the title field, it
+doesn't make sense to distinguish between the field being null and simply being
+an empty string, so we don't expose that in the API. Even if your database
+schema does allow records to have a null value for this column, we can hide that
+at the implementation layer.
+
+Finally, we need to consider if `String` is actually the right type for this
+field. GraphQL provides a decent set of built-in scalar types (`String`, `Int`,
+`Boolean`, etc) but it also lets you define your own, and this is a prime use
+case for that feature. Most schemas define their own set of additional scalars
+depending on their use cases. These provide additional context and semantic
+value for clients. In this case, it probably makes sense to define a custom
+`HTML` scalar for use here (and potentially elsewhere) when the string in
+question must be valid HTML.
+
+Whenever you're adding a scalar field, it's worth checking your existing list of
+custom scalars to see if one of them would be a better fit. If you're adding a
+field and you think a new custom scalar would be appropriate, it's worth talking
+it over with your team to make sure you're capturing the right concept.
+
+*Rule #10: Use custom scalar types when you're exposing something with specific
+semantic value.*
+
+### Pagination Again
+
+That covers all of the fields in our core `Collection` type. The next object is
+`CollectionRuleSet`, which is quite simple. The only question here is whether or
+not the list of rules should be paginated. In this case the existing array
+actually makes sense; paginating the list of rules would be overkill. Most
+collections will only have a handful of rules, and there isn't a good use case
+for a collection to have a large rule set. Even a dozen rules is probably an
+indicator that you need to rethink that collection, or should just be manually
+adding products.
+
+### Enums
+
+This brings us to the final type in our schema, `CollectionRule`. Each rule
+consists of a column to match on (e.g. product title), a type of relation (e.g.
+equality) and an actual value to use (e.g. "Boots") which is confusingly called
+`condition`. That last field can be renamed, and so should `column`; column is
+very database-specific terminology, and we're working in GraphQL. `field` is
+probably a better choice.
+
+As far as types go, both `field` and `relation` are probably implemented
+internally as enumerations (assuming your language of choice even has
+enumerations). Fortunately GraphQL has enums as well, so we can convert those
+two fields to enums. Our completed schema design now looks like this:
+
+```graphql
+type Collection implements Node {
+  id: ID!
+  ruleSet: CollectionRuleSet
+  products: ProductConnection!
+  title: String!
+  image: Image
+  description: HTML!
+}
+
+type CollectionRuleSet {
+  rules: [CollectionRule!]!
+  appliesDisjunctively: Bool!
+}
+
+type CollectionRule {
+  field: CollectionRuleField!
+  relation: CollectionRuleRelation!
+  value: String!
+}
+
+enum CollectionRuleField {
+  TAG
+  TITLE
+  TYPE
+  INVENTORY
+  PRICE
+  VENDOR
+}
+
+enum CollectionRuleRelation {
+  CONTAINS
+  ENDS_WITH
+  EQUALS
+  GREATER_THAN
+  LESS_THAN
+  NOT_CONTAINS
+  NOT_EQUALS
+  STARTS_WITH
+}
+```
+
+*Rule #11: Use enums for fields which can only take a specific set of values.*
+
+## Step Four: Business Logic
+
+We now have a minimal but well-designed GraphQL API for collections. There is a
+lot of detail to collections that we haven't dealt with - any real
+implementation of this feature would need a lot more fields to deal with things
+like product sort order, publishing, etc. - but as a rule those fields will all
+follow the same design patterns laid out here. However, there are still a few
+things which bear looking at in more detail.
+
+For this section, it is most convenient to start with a motivating use case from
+the hypothetical client of our API. Let us therefore imagine that the client
+developer we have been working with needs to know something very specific:
+whether a given product is a member of a collection or not. Of course, this is
+something that the client can already answer with our existing API: we expose
+the complete set of products in a collection, so the client simply has to
+iterate through, looking for the product they care about.
+
+This solution has two problems though. The first, obvious problem is that it's
+inefficient; collections can contain millions of products, and having the client
+fetch and iterate through them all would be extremely slow. The second, bigger
+problem, is that it requires the client to write code. This last point is a
+critical piece of design philosophy: the server should always be the single
+source of truth for any business logic. An API almost always exists to serve
+more than one client, and if each of those clients has to implement the same
+logic then you've effectively got code duplication, with all the extra work and
+room for error which that entails.
+
+*Rule #12: The API should provide business logic, not just data. Complex
+calculations should be done on the server, in one place, not on the client, in
+many places.*
+
+Back to our client use-case, the best answer here is to provide a new field
+specifically dedicated to solving this problem. Practically, this looks like:
+```graphql
+type Collection implements Node {
+  # ...
+  hasProduct(id: ID!): Bool!
+}
+```
+This field takes the ID of a product and returns a boolean based on the server
+determining if a product is in the collection or not. The fact that this sort-of
+duplicates the data from the existing `products` field is irrelevant. GraphQL
+returns only what clients explicitly ask for, so unlike REST it does not cost us
+anything to add a bunch of secondary fields. The client doesn't have to write
+any code beyond querying an additional field, and the total bandwidth used is a
+single ID plus a single boolean.
+
+One follow-up warning though: just because we're providing business logic in a
+situation does not mean we don't have to provide the raw data too. Clients
+should be able to do the business logic themselves, if they have to. You can’t
+predict all of the logic a client is going to want, and there isn't always an
+easy channel for clients to ask for additional fields (though you should strive
+to ensure such a channel exists as much as possible).
+
+*Rule #13: Provide the raw data too, even when there's business logic around it.*
+
+Finally, don't let business-logic fields affect the overall shape of the API.
+The business domain data is still the core model. If you're finding the business
+logic doesn't really fit, then that's a sign that maybe your underlying model
+isn't right.
+
+## Step Five: Mutations
+
+The final missing piece of our GraphQL schema design is the ability to actually
+change values: creating, updating, and deleting collections and related pieces.
+As with the readable portion of the schema we should start with a high-level
+view: in this case, of just the various mutations we will want to implement,
+without worrying about their specific inputs or outputs. Naively we might follow
+the CRUD paradigm and have just `create`, `delete`, and `update` mutations.
+While this is a decent starting place, it is insufficient for a proper GraphQL
+API.
+
+### Separate Logical Actions
+
+The first thing we might notice if we were to stick to just CRUD is that our
+`update` mutation quickly becomes massive, responsible not just for updating
+simple scalar values like title but also for performing complex actions like
+publishing/unpublishing, adding/removing/reordering the products in the
+collection, changing the rules for automatic collections, etc. This makes it
+hard to implement on the server and hard to reason about for the client.
+Instead, we can take advantage of GraphQL to split it apart into more granular,
+logical actions. As a very first pass, we can split out publish/unpublish
+resulting in the following mutation list:
+- create
+- delete
+- update
+- publish
+- unpublish
+
+*Rule #14: Write separate mutations for separate logical actions on a resource.*
+
+### Manipulating Relationships
+
+The `update` mutation still has far too many responsibilities so it makes sense
+to continue splitting it up, but we will deal with these actions separately
+since they're worth thinking about from another dimension as well: the
+manipulation of object relationships (e.g. one-to-many, many-to-many). We've
+already considered the use of IDs vs embedding, and the use of pagination vs
+arrays in the read API, and there are some similar issues to deal with when
+mutating these relationships.
+
+For the relationship between products and collections, there are a couple of
+styles we could broadly consider:
+- Embedding the entire relationship (e.g. `products: [ProductInput!]!`) into the
+  update mutation is the CRUD-style default, but of course it quickly becomes
+  inefficient when the list is large.
+- Embedding "delta" fields (e.g. `productsToAdd: [ID!]!` and
+  `productsToRemove: [ID!]!`) into the update mutation is more efficient since
+  only the changed IDs need to be specified instead of the entire list, but it
+  still keeps the actions tied together.
+- Splitting it up entirely into separate mutations (`addProduct`,
+  `removeProduct`, etc.) is the most powerful and flexible but also the most
+  work.
+
+The last option is generally the safest call, especially since mutations like
+this will usually be distinct logical actions anyway. However, there are a lot
+of factors to consider:
+- Is the relationship large or paginated? If so, embedding the entire list is
+  definitely impractical, however either delta fields or separate mutations
+  could still work. If the relationship is always small though (especially if
+  it's one-to-one), embedding may be the simplest choice.
+- Is the relationship ordered? The product-collection relationship is ordered,
+  and permits manual reordering. Order is naturally supported by the embedded
+  list or by separate mutations (you can add a `reorderProducts` mutation)
+  but isn't an option for delta fields.
+- Is the relationship mandatory? Products and collections can both exist on
+  their own outside of the relationship, with their own create/delete lifecycle.
+  If the relationship were mandatory (i.e. products must be in a collection)
+  then this would strongly suggest separate mutations because the action would
+  actually be to *create* a product, not just to update the relationship.
+- Do both sides have IDs? The collection-rule relationship is mandatory (rules
+  can't exist without collections) but rules don't even have IDs; they are
+  clearly subservient to their collection, and since the relationship is also
+  small, embedding the list is actually not a bad choice here. Anything else
+  would require rules to be individually identifiable and that feels like
+  overkill.
+
+*Rule #15: Mutating relationships is really complicated and not easily
+ summarized into a snappy rule.*
+
+ If you stir all of this together, for collections we end up with the following
+ list of mutations:
+- create
+- delete
+- update
+- publish
+- unpublish
+- addProducts
+- removeProducts
+- reorderProducts
+
+Products we split into their own mutations, because the relationship is large
+and ordered. Rules we left inline because the relationship is small, and rules
+are sufficiently minor to not have IDs.
+
+Finally, you may note our product mutations act on sets of products, for example
+`addProducts` and not `addProduct`. This is simply a convenience for the client,
+since the common use case when manipulating this relationship will be to add,
+remove, or reorder more than one product at a time.
+
+*Rule #16: When writing separate mutations for relationships, consider whether
+ it would be useful for the mutations to operate on multiple elements at once.*
+
+### Input: Structure, Part 1
+
+Now that we know which mutations we want to write, we get to figure out what
+their input structures look like. If you've been browsing any of the real
+production schemas that are publicly available, you may have noticed that many
+mutations define a single global `Input` type to hold all of their arguments:
+this pattern was a requirement of some legacy clients but is no longer needed
+for new code; we can ignore it.
+
+For many simple mutations, an ID or a handful of IDs are all that is needed,
+making this step quite simple. Among collections, we can quickly knock out the
+following mutation arguments:
+- `delete`, `publish` and `unpublish` all simply need a single collection ID
+- `addProducts` and `removeProducts` both need the collection ID as well as a
+  list of product IDs
+
+This leaves us with only three remaining "complicated" inputs to design:
+- create
+- update
+- reorderProducts
+
+Let's start with create. A very naive input might look kind of like our original
+naive collection model when we started, but we can already do better than that.
+Based on our final collection model and the discussion of relationships above,
+we can start with something like this:
+
+```graphql
+type Mutation {
+  collectionDelete(collectionId: ID!)
+  collectionPublish(collectionId: ID!)
+  collectionUnpublish(collectionId: ID!)
+  collectionAddProducts(collectionId: ID!, productIds: [ID!]!)
+  collectionRemoveProducts(collectionId: ID!, productIds: [ID!])
+  collectionCreate(title: String!, ruleSet: CollectionRuleSetInput, image: ImageInput, description: HTML!)
+}
+
+input CollectionRuleSetInput {
+  rules: [CollectionRuleInput!]!
+  appliesDisjunctively: Bool!
+}
+
+input CollectionRuleInput {
+  field: CollectionRuleField!
+  relation: CollectionRuleRelation!
+  value: String!
+}
+```
+
+First a quick note on naming: you'll notice that we named all of our mutations
+in the form `collection<Action>` rather than the more naturally-English
+`<action>Collection`. Unfortunately, GraphQL does not provide a method for
+grouping or otherwise organizing mutations, so we are forced into
+alphabetization as a workaround. Putting the core type first ensures that all of
+the related mutations group together in the final list.
+
+*Rule #17: Prefix mutation names with the object they are mutating for
+ alphabetical grouping (e.g. use `orderCancel` instead of `cancelOrder`).*
+
+### Input: Scalars
+
+This draft is a lot better than a completely naive approach, but it still isn't
+perfect. In particular, the `description` input field has a couple of issues. A
+non-null `HTML` field makes sense for the output of a collection's description,
+but it doesn't work as well for input for a couple of reasons. First-off, while
+`!` denotes non-nullability on output, it doesn't mean quite the same thing on
+input; instead it denotes more the concept of whether a field is "required". A
+required field is one the client must provide in order for the request to
+proceed, and this isn't true for `description`. We don't want to prevent clients
+from creating collections if they don't provide a description (or equivalently,
+we don't want to force them to provide a useless `""`), so we should make
+`description` non-required.
+
+*Rule #18: Only make input fields required if they're actually semantically
+ required for the mutation to proceed.*
+
+The other issue with `description` is its type; this may seem counter-intuitive
+since it is already strongly-typed (`HTML` instead of `String`) and we've been
+all about strong typing so far. But again, inputs behave a little differently.
+Validation of strong typing on input happens at the GraphQL layer before any
+"userspace" code gets run, which means that realistically clients have to deal
+with two layers of errors: GraphQL-layer validation errors, and business-layer
+validation errors (for example something like: you've reached the limit of
+collections you can create with your current storage). In order to simplify this
+process, we intentionally weakly type input fields when it might be difficult
+for the client to validate up-front. This lets the business-logic side handle
+all of the validation, and lets the client only deal with errors from one spot.
+
+*Rule #19: Use weaker types for inputs (e.g. `String` instead of `Email`) when
+ the format is unambiguous and client-side validation is complex. This lets the
+ server run all non-trivial validations at once and return the errors in a
+ single place in a single format, simplifying the client.*
+
+It is important to note, though, that this is not an invitation to weakly-type
+all your inputs. We still use strongly-typed enums for the `field` and
+`relation` values on our rule input, and we would still use strong typing for
+certain other inputs like `DateTime`s if we had any in this example. The key
+differentiating factors are the complexity of client-side validation and the
+ambiguity of the format. HTML is a well-defined, unambiguous specification, but
+is quite complex to validate. On the other hand, there are hundreds of ways to
+represent a date or time as a string, all of them reasonably simple, so it
+benefits from a strong scalar type to specify which format we expect.
+
+*Rule #20: Use stronger types for inputs (e.g. `DateTime` instead of `String`)
+ when the format may be ambiguous and client-side validation is simple. This
+ provides clarity and encourages clients to use stricter input controls (e.g. a
+ date-picker widget instead of a free-text field).*
+
+### Input: Structure, Part 2
+
+Continuing on to the update mutation, it might look something like this:
+
+```graphql
+type Mutation {
+  # ...
+  collectionCreate(title: String!, ruleSet: CollectionRuleSetInput, image: ImageInput, description: String)
+  collectionUpdate(collectionId: ID!, title: String, ruleSet: CollectionRuleSetInput, image: ImageInput, description: String)
+}
+```
+
+You'll note that this is very similar to our create mutation, with two
+differences: a `collectionId` argument was added, which determines which
+collection to update, and `title` is no longer required since the collection
+must already have one. Ignoring the title's required status for a moment, our
+example mutations have four duplicate arguments, and a complete collections
+model would include quite a few more.
+
+While there are some arguments for leaving these mutations as-is, we have
+decided that situations like this call for DRYing up the common portions of the
+arguments, even at the cost of requiredness. This has a couple of advantages:
+- We end up with a single input object representing the concept of a collection
+  and mirroring the single `Collection` type our schema already has.
+- Clients can share code between their create and update forms (a common
+  pattern) because they end up manipulating the same kind of input object.
+- Mutations remain slim and readable with only a couple of top-level arguments.
+
+The primary cost, of course, is that it's no longer clear from the schema that
+the title is required on creation. Our schema ends up looking like this:
+
+```graphql
+type Mutation {
+  # ...
+  collectionCreate(collection: CollectionInput!)
+  collectionUpdate(collectionId: ID!, collection: CollectionInput!)
+}
+
+input CollectionInput {
+  title: String
+  ruleSet: CollectionRuleSetInput
+  image: ImageInput
+  description: String
+}
+```
+
+*Rule #21: Structure mutation inputs to reduce duplication, even if this
+ requires relaxing requiredness constraints on certain fields.*
+
+### Output
+
+The final design question we need to deal with is the return value of our
+mutations. Typically mutations can succeed or fail, and while GraphQL does
+include explicit support for query-level errors, these are not ideal for
+business-level mutation failures. Instead, we reserve these top-level errors for
+failures of the client (e.g. requesting a non-existant field) rather than of the
+user. As such, each mutation should define a "payload" type which includes a
+user-errors field in addition to any other values that might be useful. For
+create, that might look like this:
+
+```graphql
+type CollectionCreatePayload {
+  userErrors: [UserError!]!
+  collection: Collection
+}
+
+type UserError {
+  message: String!
+
+  # Path to input field which caused the error.
+  field: [String!]
+}
+```
+
+Here, a successful mutation would return an empty list for `userErrors` and
+would return the newly-created collection for the `collection` field. An
+unsuccessful mutation would return one or more `UserError` objects, and `null`
+for the collection.
+
+*Rule #22: Mutations should provide user/business-level errors via a
+ `userErrors` field on the mutation payload. The top-level query errors entry is
+ reserved for client and server-level errors.*
+
+In many implementations, much of this structure is provided automatically, and
+all you will have to define is the `collection` return field.
+
+For the update mutation, we follow exactly the same pattern:
+
+```graphql
+type CollectionUpdatePayload {
+  userErrors: [UserError!]!
+  collection: Collection
+}
+```
+
+It's worth noting that `collection` is still nullable even here, since if the
+provided ID doesn't represent a valid collection, there is no collection to
+return.
+
+*Rule #23: Most payload fields for a mutation should be nullable, unless there
+ is really a value to return in every possible error case.*
+
+## TLDR: The rules
+
+- Rule #1: Always start with a high-level view of the objects and their relationships before you deal with specific fields.
+- Rule #2: Never expose implementation details in your API design.
+- Rule #3: Design your API around the business domain, not the implementation, user-interface, or legacy APIs.
+- Rule #4: It’s easier to add fields than to remove them.
+- Rule #5: Major business-object types should always implement Node.
+- Rule #6: Group closely-related fields together into subobjects.
+- Rule #7: Always check whether list fields should be paginated or not.
+- Rule #8: Always use object references instead of ID fields.
+- Rule #9: Choose field names based on what makes sense, not based on the implementation or what the field is called in legacy APIs.
+- Rule #10: Use custom scalar types when you’re exposing something with specific semantic value.
+- Rule #11: Use enums for fields which can only take a specific set of values.
+- Rule #12: The API should provide business logic, not just data. Complex calculations should be done on the server, in one place, not on the client, in many places.
+- Rule #13: Provide the raw data too, even when there’s business logic around it.
+- Rule #14: Write separate mutations for separate logical actions on a resource.
+- Rule #15: Mutating relationships is really complicated and not easily summarized into a snappy rule.
+- Rule #16: When writing separate mutations for relationships, consider whether it would be useful for the mutations to operate on multiple elements at once.
+- Rule #17: Prefix mutation names with the object they are mutating for
+ alphabetical grouping (e.g. use `orderCancel` instead of `cancelOrder`).
+- Rule #18: Only make input fields required if they're actually semantically required for the mutation to proceed.
+- Rule #19: Use weaker types for inputs (e.g. String instead of Email) when the format is unambiguous and client-side validation is complex. This lets the server run all non-trivial validations at once and return the errors in a single place in a single format, simplifying the client.
+- Rule #20: Use stronger types for inputs (e.g. DateTime instead of String) when the format may be ambiguous and client-side validation is simple. This provides clarity and encourages clients to use stricter input controls (e.g. a date-picker widget instead of a free-text field).
+- Rule #21: Structure mutation inputs to reduce duplication, even if this requires relaxing requiredness constraints on certain fields.
+- Rule #22: Mutations should provide user/business-level errors via a userErrors field on the mutation payload. The top-level query errors entry is reserved for client and server-level errors.
+- Rule #23: Most payload fields for a mutation should be nullable, unless there is really a value to return in every possible error case.
+
+## Conclusion
+
+Thank you for reading our tutorial! Hopefully by this point you have a solid
+idea of how to design a good GraphQL API.
+
+Once you've designed an API you're happy with, it's time to implement it!

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -733,8 +733,7 @@ HTMLはうまく定義されていて、明瞭な仕様がありますが、検�
 
 ### Input: Structure, Part 2
 
-
-Continuing on to the update mutation, it might look something like this:
+つづいてupdate操作をみていきます。
 
 ```graphql
 type Mutation {
@@ -744,24 +743,21 @@ type Mutation {
 }
 ```
 
-You'll note that this is very similar to our create mutation, with two
-differences: a `collectionId` argument was added, which determines which
-collection to update, and `title` is no longer required since the collection
-must already have one. Ignoring the title's required status for a moment, our
-example mutations have four duplicate arguments, and a complete collections
-model would include quite a few more.
+二つの点を除いて、updateのmutationがcreateに非常に似ていることに気付いたかもしれません。
+更新対象のコレクションを示す引数`collectionId`が追加され、またコレクションは既に`title`を持っているため必須制約が外れました。
+`title`を必須制約を無視すれば、これら２つのmutationは共通する４つの引数を持ち、完全なコレクションモデルはさらに多くの引数を含むでしょう。
 
-While there are some arguments for leaving these mutations as-is, we have
-decided that situations like this call for DRYing up the common portions of the
-arguments, even at the cost of requiredness. This has a couple of advantages:
-- We end up with a single input object representing the concept of a collection
-  and mirroring the single `Collection` type our schema already has.
-- Clients can share code between their create and update forms (a common
-  pattern) because they end up manipulating the same kind of input object.
-- Mutations remain slim and readable with only a couple of top-level arguments.
+いくつかの引数はそのままにしておくべきだという議論がある一方で、このような状況において、我々は必須制約を犠牲にしても引数の共通部分をDRYにする結論をだしました。
 
-The primary cost, of course, is that it's no longer clear from the schema that
-the title is required on creation. Our schema ends up looking like this:
+この決定はいくつかの利点を提供します。
+
+- スキーマにすでに存在している`Collection`型を利用し、コレクションの概念を表すひとつの入力オブジェクトを受け取ります。
+- 同じ入力オブジェクトを操作するため、クライアントはcreateとupdateの入力フォームを共通のコードで管理できます。
+- トップレベルでは少数の引数を受け取るだけで済むため、mutationはスリムで可読性に優れています。
+
+主たるデメリットとしては、スキーマからはもはやcreate操作時にtitleが必須であるという条件を明示的に読み取れないことが考えられます。
+
+スキーマは以下のようになります。
 
 ```graphql
 type Mutation {
@@ -778,8 +774,7 @@ input CollectionInput {
 }
 ```
 
-*Rule #21: Structure mutation inputs to reduce duplication, even if this
- requires relaxing requiredness constraints on certain fields.*
+*ルール #21: たとえいくつかのフィールドの必須制約を緩和する必要があっても、重複を減らすためにmutationの入力を構造化すること。*
 
 ### Output
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -778,14 +778,12 @@ input CollectionInput {
 
 ### Output
 
-The final design question we need to deal with is the return value of our
-mutations. Typically mutations can succeed or fail, and while GraphQL does
-include explicit support for query-level errors, these are not ideal for
-business-level mutation failures. Instead, we reserve these top-level errors for
-failures of the client (e.g. requesting a non-existant field) rather than of the
-user. As such, each mutation should define a "payload" type which includes a
-user-errors field in addition to any other values that might be useful. For
-create, that might look like this:
+設計に関する問題で最後に扱うのはmutationの戻り値です。
+基本的にmutationは実行結果として成功か、さもなくば失敗に到達します。
+GraphQLは明示的にはクエリーレベルのエラー処理を提供するものの、ビジネスロジックレベルにおけるmutationのエラーとしては最適なものではありません。
+トップレベルのエラーはユーザ操作に対するエラーよりもむしろクライアント向けのエラー（例えば無効なフィールドの要求）の情報を提供するためにとっておきます。
+その代わり、各mutationはその他の必要な情報に加えてユーザエラーフィールドを含む"payload"型を定義すべきです。
+createのmutationはおそらく以下のようになるでしょう。
 
 ```graphql
 type CollectionCreatePayload {
@@ -801,19 +799,16 @@ type UserError {
 }
 ```
 
-Here, a successful mutation would return an empty list for `userErrors` and
-would return the newly-created collection for the `collection` field. An
-unsuccessful mutation would return one or more `UserError` objects, and `null`
-for the collection.
+処理に成功したmutationは空リストの`userErrors`と、`collection`フィールドには新たに作成されたコレクションを入れて返します。
+処理に失敗したmutationはひとつ以上の`UserError`オブジェクトを含むリストと、コレクションには`nil`を入れて返します。
 
-*Rule #22: Mutations should provide user/business-level errors via a
- `userErrors` field on the mutation payload. The top-level query errors entry is
- reserved for client and server-level errors.*
+*ルール #22: mutationはビジネスロジックレベルのエラーを`userErrors`フィールドに入れて返すこと。
+トップレベルのエラーフィールドはクライアントおよびサーバーレベルのエラーのために残しておくこと。*
 
-In many implementations, much of this structure is provided automatically, and
-all you will have to define is the `collection` return field.
+多くの実装においてこの構造の大半は自動的に提供されます。
+そのため、ここで為すべきは`collection`フィールドを定義することです。
 
-For the update mutation, we follow exactly the same pattern:
+updateのmutationに関しても同じパターンに従います。
 
 ```graphql
 type CollectionUpdatePayload {
@@ -822,12 +817,10 @@ type CollectionUpdatePayload {
 }
 ```
 
-It's worth noting that `collection` is still nullable even here, since if the
-provided ID doesn't represent a valid collection, there is no collection to
-return.
+ここでも依然として`collection`がNullableになっていることに注目してください。
+有効なコレクションのIDが渡されない場合には、返すべきコレクションがありません。
 
-*Rule #23: Most payload fields for a mutation should be nullable, unless there
- is really a value to return in every possible error case.*
+*ルール #23: すべてのエラーケースおいて返せる特定の値がないのであれば、mutationが返すほとんどのフィールドはNullableであること。*
 
 ## TLDR: The rules
 

--- a/lang/TUTORIAL_JAPANESE.md
+++ b/lang/TUTORIAL_JAPANESE.md
@@ -562,33 +562,28 @@ GraphQLはクライアントから明示的に要求されたものだけを返�
 
 ## Step Five: Mutations
 
-The final missing piece of our GraphQL schema design is the ability to actually
-change values: creating, updating, and deleting collections and related pieces.
-As with the readable portion of the schema we should start with a high-level
-view: in this case, of just the various mutations we will want to implement,
-without worrying about their specific inputs or outputs. Naively we might follow
-the CRUD paradigm and have just `create`, `delete`, and `update` mutations.
-While this is a decent starting place, it is insufficient for a proper GraphQL
-API.
+我々のGraphQLスキーマに足りていない最後のピースはデータを変更する機能です。
+コレクションを追加、変更したり、コレクションと関連するオブジェクトを削除するといった操作です。
+スキーマのクエリ部分と同様に、高いレベルから見ていくべきです。
+ここでは、個々の入出力にとらわれず、まずはどのような種類のmutationが必要か考えてみましょう。
+素朴にCRUD操作のパラダイムに従い、`create`、`delete`、そして`update`操作のmutationを設けてみます。
+これは議論を始めるにはちょうど良いものの、正しいGraphQL APIとしては不十分です。
 
 ### Separate Logical Actions
 
-The first thing we might notice if we were to stick to just CRUD is that our
-`update` mutation quickly becomes massive, responsible not just for updating
-simple scalar values like title but also for performing complex actions like
-publishing/unpublishing, adding/removing/reordering the products in the
-collection, changing the rules for automatic collections, etc. This makes it
-hard to implement on the server and hard to reason about for the client.
-Instead, we can take advantage of GraphQL to split it apart into more granular,
-logical actions. As a very first pass, we can split out publish/unpublish
-resulting in the following mutation list:
+CRUDに従おうとすると、すぐに`update`が巨大になるということにまず気付くと思います。
+タイトルのようなシンプルなスカラー値を更新するだけではなく、コレクションの公開や非公開、商品の追加/削除/並べ替え操作、自動コレクションのルールの変更といったあらゆる複雑な操作がupdateの責任範囲となります。
+サーバーは実装が困難になり、クライアントは論理的に考えて利用することが難しくなります。
+対案として、`update`操作を論理的に細かい粒度に分解できるというGraphQLの利点を活かすことができます。
+手始めに公開・非公開の操作を切り出すことで、以下のmutationのリストを得ます。
+
 - create
 - delete
 - update
 - publish
 - unpublish
 
-*Rule #14: Write separate mutations for separate logical actions on a resource.*
+*ルール #14: リソースに対するロジックの異なる操作にはそれぞれmutationを用意すること。*
 
 ### Manipulating Relationships
 


### PR DESCRIPTION
I've been working in a team in which employing GraphQL as a tech-stuck.
I really appreciate that Shopify provides such an educational tutorial, I've got good ideas from it.

This PR adds a Japanese translated version of the tutorial so as to make it easy for other japanese people to get awesome ideas there.

Thank you again for publishing the tutorial.