### PR TITLE
Fix missing non-null marker in 'Input: Structure' section

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -812,7 +812,7 @@ type Mutation {
   collectionPublish(collectionId: ID!)
   collectionUnpublish(collectionId: ID!)
   collectionAddProducts(collectionId: ID!, productIds: [ID!]!)
-  collectionRemoveProducts(collectionId: ID!, productIds: [ID!])
+  collectionRemoveProducts(collectionId: ID!, productIds: [ID!]!)
   collectionCreate(title: String!, ruleSet: CollectionRuleSetInput, image: ImageInput, description: HTML!)
 }
 


### PR DESCRIPTION
The non-null marker seems to be a missing for the given productIds array argument for `collectionRemoveProducts`, presumably due to a typo, since removing with a nullable input seems incorrect. This PR adds the explanation mark in this example to clarify it.
This is substantiated by the fact that this is not optional in a similar example later in the tutorial, see https://github.com/Shopify/graphql-design-tutorial/blob/master/TUTORIAL.md#manipulating-relationships