### PR TITLE
Fix typo in TUTORIAL.md

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -237,7 +237,7 @@ our implementation at some point to permit some third method of choosing
 products (machine learning?) or to permit mixing methods (some rules and some
 manually added products) and *they would still just be collections*. You could
 even argue that the fact we don't permit mixing right now is an implementation
-failure. All of this to say is that the shape of our API should really look more
+failure. All that is to say the shape of our API should really look more
 like this:
 
 ```graphql


### PR DESCRIPTION
"All of this to say is that..." -> "All that is to say..."
This is tough phrasing to find common usages of.
In the end I went with a simpler phrasing that avoids repeated this-es or thats, given the sentence ends with a this.